### PR TITLE
Normalize UI appointments → use prismaToUI (date/service normalization) + types & tests

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  reactStrictMode: false,
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,23 @@
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@hookform/resolvers": "^5.0.1",
+        "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^6.8.2",
         "@radix-ui/themes": "^3.2.1",
         "@types/bcrypt": "^5.0.2",
         "bcrypt": "^6.0.0",
+        "chart.js": "^4.5.0",
+        "date-fns": "^4.1.0",
         "framer-motion": "^12.15.0",
         "jsonwebtoken": "^9.0.2",
         "keen-slider": "^6.8.6",
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.511.0",
         "next": "15.3.3",
+        "next-auth": "^4.24.11",
         "react": "^19.0.0",
+        "react-calendar": "^6.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "react-google-recaptcha": "^3.1.0",
         "react-hook-form": "^7.57.0",
@@ -32,8 +38,9 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/chart.js": "^2.9.41",
         "@types/jsonwebtoken": "^9.0.10",
-        "@types/node": "^20",
+        "@types/node": "^24.5.2",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/react-google-recaptcha": "^2.1.9",
@@ -41,7 +48,8 @@
         "eslint-config-next": "15.3.3",
         "prisma": "^6.8.2",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -69,6 +77,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -102,6 +119,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -858,6 +1317,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.10.tgz",
@@ -869,6 +1334,16 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@next-auth/prisma-adapter": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@next-auth/prisma-adapter/-/prisma-adapter-1.0.7.tgz",
+      "integrity": "sha512-Cdko4KfcmKjsyHFrWwZ//lfLUbcLqlyFqjd/nYE2m3aZ7tjMNUjpks47iw7NTCnXf+5UWz5Ypyt1dSs1EP5QJw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@prisma/client": ">=2.26.0 || >=3",
+        "next-auth": "^4"
       }
     },
     "node_modules/@next/env": {
@@ -1061,6 +1536,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@prisma/client": {
@@ -2798,6 +3282,314 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
+      "integrity": "sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.3.tgz",
+      "integrity": "sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.3.tgz",
+      "integrity": "sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.3.tgz",
+      "integrity": "sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.3.tgz",
+      "integrity": "sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.3.tgz",
+      "integrity": "sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.3.tgz",
+      "integrity": "sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.3.tgz",
+      "integrity": "sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.3.tgz",
+      "integrity": "sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.3.tgz",
+      "integrity": "sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.3.tgz",
+      "integrity": "sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.3.tgz",
+      "integrity": "sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.3.tgz",
+      "integrity": "sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.3.tgz",
+      "integrity": "sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.3.tgz",
+      "integrity": "sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.3.tgz",
+      "integrity": "sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.3.tgz",
+      "integrity": "sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.3.tgz",
+      "integrity": "sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.3.tgz",
+      "integrity": "sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.3.tgz",
+      "integrity": "sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3162,6 +3954,26 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/chart.js": {
+      "version": "2.9.41",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.41.tgz",
+      "integrity": "sha512-3dvkDvueckY83UyUXtJMalYoH6faOLkWQoaTlJgB4Djde3oORmNP0Jw85HtzTuXyliUHcdp704s0mZFQKio/KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.10.2"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3225,10 +4037,17 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3265,12 +4084,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.57",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
-      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/react": {
@@ -3310,17 +4129,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.0.tgz",
-      "integrity": "sha512-CACyQuqSHt7ma3Ns601xykeBK/rDeZa3w6IS6UtMQbixO5DWy+8TilKkviGDH6jtWCo8FGRKEK5cLLkPvEammQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.33.0",
-        "@typescript-eslint/type-utils": "8.33.0",
-        "@typescript-eslint/utils": "8.33.0",
-        "@typescript-eslint/visitor-keys": "8.33.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/type-utils": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -3334,9 +4153,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.33.0",
+        "@typescript-eslint/parser": "^8.44.1",
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -3350,16 +4169,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.0.tgz",
-      "integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.33.0",
-        "@typescript-eslint/types": "8.33.0",
-        "@typescript-eslint/typescript-estree": "8.33.0",
-        "@typescript-eslint/visitor-keys": "8.33.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3371,18 +4190,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.0.tgz",
-      "integrity": "sha512-d1hz0u9l6N+u/gcrk6s6gYdl7/+pp8yHheRTqP6X5hVDKALEaTn8WfGiit7G511yueBEL3OpOEpD+3/MBdoN+A==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.33.0",
-        "@typescript-eslint/types": "^8.33.0",
+        "@typescript-eslint/tsconfig-utils": "^8.44.1",
+        "@typescript-eslint/types": "^8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3391,17 +4210,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.0.tgz",
-      "integrity": "sha512-LMi/oqrzpqxyO72ltP+dBSP6V0xiUb4saY7WLtxSfiNEBI8m321LLVFU9/QDJxjDQG9/tjSqKz/E3380TEqSTw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.33.0",
-        "@typescript-eslint/visitor-keys": "8.33.0"
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3412,9 +4234,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.0.tgz",
-      "integrity": "sha512-sTkETlbqhEoiFmGr1gsdq5HyVbSOF0145SYDJ/EQmXHtKViCaGvnyLqWFFHtEXoS0J1yU8Wyou2UGmgW88fEug==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3425,18 +4247,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.0.tgz",
-      "integrity": "sha512-lScnHNCBqL1QayuSrWeqAL5GmqNdVUQAAMTaCwdYEdWfIrSrOGzyLGRCHXcCixa5NK6i5l0AfSO2oBSjCjf4XQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.33.0",
-        "@typescript-eslint/utils": "8.33.0",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -3449,13 +4272,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.0.tgz",
-      "integrity": "sha512-DKuXOKpM5IDT1FA2g9x9x1Ug81YuKrzf4mYX8FAVSNu5Wo/LELHWQyM1pQaDkI42bX15PWl0vNPt1uGiIFUOpg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3467,16 +4290,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.0.tgz",
-      "integrity": "sha512-vegY4FQoB6jL97Tu/lWRsAiUUp8qJTqzAmENH2k59SJhw0Th1oszb9Idq/FyyONLuNqT1OADJPXfyUNOR8SzAQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.33.0",
-        "@typescript-eslint/tsconfig-utils": "8.33.0",
-        "@typescript-eslint/types": "8.33.0",
-        "@typescript-eslint/visitor-keys": "8.33.0",
+        "@typescript-eslint/project-service": "8.44.1",
+        "@typescript-eslint/tsconfig-utils": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3492,13 +4315,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3552,16 +4375,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.0.tgz",
-      "integrity": "sha512-lPFuQaLA9aSNa7D5u2EpRiqdAUhzShwGg/nhpBlc4GR6kcTABttCuyjFs8BcEZ8VWrjCBof/bePhP3Q3fS+Yrw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.33.0",
-        "@typescript-eslint/types": "8.33.0",
-        "@typescript-eslint/typescript-estree": "8.33.0"
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3572,18 +4395,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.0.tgz",
-      "integrity": "sha512-7RW7CMYoskiz5OOGAWjJFxgb7c5UNjTG292gYhWeOAcFmYCtVCSqjqSBj5zMhxbXo2JOW95YYrUWJfU0zrpaGQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.33.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.44.1",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3834,6 +4657,130 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-2.0.2.tgz",
+      "integrity": "sha512-Do66mSlSNifFFuo3l9gNKfRMSFi26CRuQMsDJuuKO/ekrDWuTTtE4ZQxoFCUOG+NgxnpSeBq/k5TY8ZseEzLpA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -4077,6 +5024,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4192,6 +5149,16 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4272,6 +5239,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4287,6 +5271,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -4371,6 +5377,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4576,6 +5591,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -4599,6 +5624,16 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4834,6 +5869,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4903,6 +5945,48 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5267,9 +6351,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5333,6 +6417,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5348,6 +6442,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5517,6 +6621,21 @@
         }
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5635,6 +6754,18 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-user-locale": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-3.0.0.tgz",
+      "integrity": "sha512-iJfHSmdYV39UUBw7Jq6GJzeJxUr4U+S03qdhVuDsR9gCEnfbqLy9gYDJFBJQL1riqolFUKQvx36mEkp2iGgJ3g==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize": "^10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
       }
     },
     "node_modules/glob-parent": {
@@ -6331,6 +7462,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6828,6 +7968,31 @@
       "integrity": "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==",
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-cache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/lucide-react": {
       "version": "0.511.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
@@ -6857,6 +8022,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+      "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6879,6 +8059,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -6941,6 +8133,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/motion-dom": {
@@ -7059,6 +8261,38 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7107,6 +8341,12 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7114,6 +8354,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -7229,6 +8478,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7337,6 +8610,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7367,9 +8657,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -7395,6 +8685,28 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7404,6 +8716,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prisma": {
       "version": "6.8.2",
@@ -7570,6 +8888,41 @@
       },
       "peerDependencies": {
         "react": ">=16.4.1"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-6.0.0.tgz",
+      "integrity": "sha512-6wqaki3Us0DNDjZDr0DYIzhSFprNoy4FdPT9Pjy5aD2hJJVjtJwmdMT9VmrTUo949nlk35BOxehThxX62RkuRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^2.0.2",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^3.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -7863,6 +9216,48 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
+      "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.3",
+        "@rollup/rollup-android-arm64": "4.52.3",
+        "@rollup/rollup-darwin-arm64": "4.52.3",
+        "@rollup/rollup-darwin-x64": "4.52.3",
+        "@rollup/rollup-freebsd-arm64": "4.52.3",
+        "@rollup/rollup-freebsd-x64": "4.52.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.3",
+        "@rollup/rollup-linux-arm64-musl": "4.52.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.3",
+        "@rollup/rollup-linux-x64-gnu": "4.52.3",
+        "@rollup/rollup-linux-x64-musl": "4.52.3",
+        "@rollup/rollup-openharmony-arm64": "4.52.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.3",
+        "@rollup/rollup-win32-x64-gnu": "4.52.3",
+        "@rollup/rollup-win32-x64-msvc": "4.52.3",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -8172,6 +9567,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -8195,6 +9597,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8356,6 +9772,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -8452,15 +9888,29 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -8470,11 +9920,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -8485,9 +9938,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8495,6 +9948,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8634,9 +10117,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -8667,9 +10150,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8767,6 +10250,15 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
@@ -8787,6 +10279,230 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
+      "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {
@@ -8892,6 +10608,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,20 +9,30 @@
     "postinstall": "prisma generate && prisma migrate deploy",
     "lint": "next lint"
   },
+  "test": "vitest",
+  "prisma": {
+    "seed": "node prisma/seed.js"
+  },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
     "@hookform/resolvers": "^5.0.1",
+    "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.8.2",
     "@radix-ui/themes": "^3.2.1",
     "@types/bcrypt": "^5.0.2",
     "bcrypt": "^6.0.0",
+    "chart.js": "^4.5.0",
+    "date-fns": "^4.1.0",
     "framer-motion": "^12.15.0",
     "jsonwebtoken": "^9.0.2",
     "keen-slider": "^6.8.6",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.511.0",
     "next": "15.3.3",
+    "next-auth": "^4.24.11",
     "react": "^19.0.0",
+    "react-calendar": "^6.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-google-recaptcha": "^3.1.0",
     "react-hook-form": "^7.57.0",
@@ -33,8 +43,9 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/chart.js": "^2.9.41",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/node": "^20",
+    "@types/node": "^24.5.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-google-recaptcha": "^2.1.9",
@@ -42,6 +53,7 @@
     "eslint-config-next": "15.3.3",
     "prisma": "^6.8.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/prisma/migrations/20250927124600_add_services_and_workinghours/migration.sql
+++ b/prisma/migrations/20250927124600_add_services_and_workinghours/migration.sql
@@ -1,0 +1,67 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `date` on the `Appointment` table. All the data in the column will be lost.
+  - You are about to drop the column `service` on the `Appointment` table. All the data in the column will be lost.
+  - Added the required column `endTime` to the `Appointment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `serviceId` to the `Appointment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `startTime` to the `Appointment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Appointment" DROP COLUMN "date",
+DROP COLUMN "service",
+ADD COLUMN     "endTime" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "serviceId" TEXT NOT NULL,
+ADD COLUMN     "startTime" TIMESTAMP(3) NOT NULL;
+
+-- CreateTable
+CREATE TABLE "WorkingHours" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "dayOfWeek" INTEGER NOT NULL,
+    "openTime" TEXT NOT NULL,
+    "closeTime" TEXT NOT NULL,
+
+    CONSTRAINT "WorkingHours_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Service" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "price" DOUBLE PRECISION NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Service_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProfessionalService" (
+    "id" TEXT NOT NULL,
+    "professionalId" TEXT NOT NULL,
+    "serviceId" TEXT NOT NULL,
+
+    CONSTRAINT "ProfessionalService_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProfessionalService_professionalId_serviceId_key" ON "ProfessionalService"("professionalId", "serviceId");
+
+-- AddForeignKey
+ALTER TABLE "WorkingHours" ADD CONSTRAINT "WorkingHours_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Service" ADD CONSTRAINT "Service_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProfessionalService" ADD CONSTRAINT "ProfessionalService_professionalId_fkey" FOREIGN KEY ("professionalId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProfessionalService" ADD CONSTRAINT "ProfessionalService_serviceId_fkey" FOREIGN KEY ("serviceId") REFERENCES "Service"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Appointment" ADD CONSTRAINT "Appointment_serviceId_fkey" FOREIGN KEY ("serviceId") REFERENCES "Service"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,19 +41,21 @@ model RateLimit {
 }
 
 model Company {
-  id            String      @id @default(cuid())
+  id            String       @id @default(cuid())
   nomeFantasia  String
   razaoSocial   String?
-  cnpjCpf       String      @unique
+  cnpjCpf       String       @unique
   endereco      String?
   telefone      String?
   email         String?
   contrato      ContractType @default(FREE)
-  createdAt     DateTime    @default(now())
-  updatedAt     DateTime @updatedAt
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
 
   users         User[]
   appointments  Appointment[]
+  workingHours  WorkingHours[]
+  services      Service[]
 }
 
 enum ContractType {
@@ -61,6 +63,40 @@ enum ContractType {
   PRO
   PREMIUM
   ENTERPRISE
+}
+
+model WorkingHours {
+  id         String   @id @default(cuid())
+  companyId  String
+  company    Company  @relation(fields: [companyId], references: [id])
+  dayOfWeek  Int      // 0 = Domingo, 6 = Sábado
+  openTime   String   // formato HH:mm
+  closeTime  String   // formato HH:mm
+}
+
+model Service {
+  id          String               @id @default(cuid())
+  companyId   String
+  company     Company              @relation(fields: [companyId], references: [id])
+  name        String
+  price       Float
+  duration    Int                  // em minutos
+  createdAt   DateTime             @default(now())
+  updatedAt   DateTime             @updatedAt
+
+  appointments Appointment[]
+  professionals ProfessionalService[]
+}
+
+model ProfessionalService {
+  id             String  @id @default(cuid())
+  professionalId String
+  serviceId      String
+
+  professional   User    @relation(fields: [professionalId], references: [id])
+  service        Service @relation(fields: [serviceId], references: [id])
+
+  @@unique([professionalId, serviceId]) // um profissional não pode ter o mesmo serviço duplicado
 }
 
 model User {
@@ -75,7 +111,9 @@ model User {
   updatedAt     DateTime      @updatedAt
 
   appointments  Appointment[] @relation("UserAppointments")
+  services      ProfessionalService[]
 }
+
 
 
 enum Role {
@@ -85,21 +123,22 @@ enum Role {
 }
 
 model Appointment {
-  id             String          @id @default(cuid())
+  id             String            @id @default(cuid())
   companyId      String
-  company        Company         @relation(fields: [companyId], references: [id])
+  company        Company           @relation(fields: [companyId], references: [id])
   professionalId String
-  professional   User            @relation("UserAppointments", fields: [professionalId], references: [id])
+  professional   User              @relation("UserAppointments", fields: [professionalId], references: [id])
   clientName     String
-  service        String
+  serviceId      String
+  service        Service           @relation(fields: [serviceId], references: [id])
   price          Float?
-  date           DateTime
+  startTime      DateTime
+  endTime        DateTime
   status         AppointmentStatus @default(PENDING)
 
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  createdAt      DateTime          @default(now())
+  updatedAt      DateTime          @updatedAt
 }
-
 
 enum AppointmentStatus {
   PENDING

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,119 @@
+const { PrismaClient } = require("../src/generated/prisma");
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // Criar empresa
+  const company = await prisma.company.create({
+    data: {
+      nomeFantasia: "Barbearia do João",
+      razaoSocial: "Barbearia do João LTDA",
+      cnpjCpf: "12345678901234",
+      telefone: "(11) 99999-9999",
+      email: "contato@barbeariadojoao.com",
+    },
+  });
+
+  // Horários de funcionamento
+  await prisma.workingHours.createMany({
+    data: [
+      {
+        companyId: company.id,
+        dayOfWeek: 1,
+        openTime: "09:00",
+        closeTime: "18:00",
+      },
+      {
+        companyId: company.id,
+        dayOfWeek: 2,
+        openTime: "09:00",
+        closeTime: "18:00",
+      },
+      {
+        companyId: company.id,
+        dayOfWeek: 3,
+        openTime: "09:00",
+        closeTime: "18:00",
+      },
+      {
+        companyId: company.id,
+        dayOfWeek: 4,
+        openTime: "09:00",
+        closeTime: "18:00",
+      },
+      {
+        companyId: company.id,
+        dayOfWeek: 5,
+        openTime: "09:00",
+        closeTime: "18:00",
+      },
+    ],
+  });
+
+  // Serviços
+  const corte = await prisma.service.create({
+    data: {
+      companyId: company.id,
+      name: "Corte de Cabelo",
+      price: 50,
+      duration: 30,
+    },
+  });
+  const barba = await prisma.service.create({
+    data: { companyId: company.id, name: "Barba", price: 35, duration: 20 },
+  });
+
+  // Usuários
+  const owner = await prisma.user.create({
+    data: {
+      name: "João Silva",
+      email: "joao@barbearia.com",
+      password: "senha123",
+      role: "OWNER",
+      companyId: company.id,
+    },
+  });
+  const employee = await prisma.user.create({
+    data: {
+      name: "Carlos Pereira",
+      email: "carlos@barbearia.com",
+      password: "senha123",
+      role: "EMPLOYEE",
+      companyId: company.id,
+    },
+  });
+
+  // Profissional ⇔ serviços
+  await prisma.professionalService.createMany({
+    data: [
+      { professionalId: employee.id, serviceId: corte.id },
+      { professionalId: employee.id, serviceId: barba.id },
+    ],
+  });
+
+  // Agendamento de teste
+  await prisma.appointment.create({
+    data: {
+      companyId: company.id,
+      professionalId: employee.id,
+      clientName: "Cliente Teste",
+      serviceId: corte.id,
+      price: 50,
+      startTime: new Date("2025-09-29T10:00:00"),
+      endTime: new Date("2025-09-29T10:30:00"),
+      status: "CONFIRMED",
+    },
+  });
+
+  console.log("🌱 Seed executado com sucesso!");
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/src/app/(app)/dashboard/appointments/AppointmentForm.tsx
+++ b/src/app/(app)/dashboard/appointments/AppointmentForm.tsx
@@ -1,104 +1,290 @@
-// src/app/dashboard/appointments/components/AppointmentForm.tsx
 "use client";
 
+import { useState, useEffect } from "react";
+import Calendar from "react-calendar";
+import "react-calendar/dist/Calendar.css";
 import Button from "@/app/components/ui/Button";
 import Input from "@/app/components/ui/Input";
-import { useState, useEffect } from "react";
 import { z } from "zod";
+import { AppointmentStatus, Appointment as PrismaAppointment } from "@/generated/prisma";
+import prismaToUI, { UIAppointment as HelperUIAppointment } from "@/lib/appointments";
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
 
 const updateAppointmentSchema = z.object({
   clientName: z.string().optional(),
   service: z.string().optional(),
   price: z.number().optional(),
   date: z.string().optional(),
-  status: z.enum(["PENDING", "CONFIRMED", "COMPLETED", "CANCELED"]).optional(),
+  status: z.nativeEnum(AppointmentStatus).optional(),
 });
 
+type UIAppointment = HelperUIAppointment;
+
 interface Props {
-  appointment: any | null;
+  appointment: UIAppointment | null;
   onClose: () => void;
 }
 
+interface AvailableSlot {
+  time: string; // "HH:mm"
+  available: boolean;
+}
+
 export default function AppointmentForm({ appointment, onClose }: Props) {
-  const [form, setForm] = useState({
+  const [form, setForm] = useState<{
+    clientName: string;
+    service: string;
+    price: number;
+    date: string;
+    status: AppointmentStatus;
+  }>({
     clientName: "",
     service: "",
     price: 0,
     date: "",
-    status: "PENDING",
+    status: AppointmentStatus.PENDING,
   });
 
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [availableSlots, setAvailableSlots] = useState<AvailableSlot[]>([]);
+  const [selectedSlot, setSelectedSlot] = useState<string | null>(null);
+
   useEffect(() => {
-    if (appointment)
-      setForm({
-        ...appointment,
-        date: new Date(appointment.date).toISOString().slice(0, 16),
-      });
+    if (!appointment) return;
+
+    // runtime type guard: detect Prisma shape (has startTime)
+    const isPrisma = (a: unknown): a is PrismaAppointment => {
+      return !!a && typeof a === "object" && "startTime" in (a as Record<string, unknown>);
+    };
+
+    const ui = isPrisma(appointment) ? prismaToUI(appointment) ?? appointment : appointment;
+
+    const safeDate = ui.date ? new Date(ui.date) : new Date();
+
+    setForm({
+      clientName: ui.clientName ?? "",
+      service: ui.service ?? "",
+      price: ui.price ?? 0,
+      date: safeDate.toISOString().slice(0, 16),
+      status: ui.status ?? AppointmentStatus.PENDING,
+    });
+
+    setSelectedDate(safeDate);
+    const slot = `${safeDate.getHours().toString().padStart(2, "0")}:00`;
+    setSelectedSlot(slot);
   }, [appointment]);
 
-  const handleSubmit = async (e: any) => {
+  // Buscar horários livres
+  useEffect(() => {
+    if (!selectedDate) return;
+
+    const fetchSlots = async () => {
+      const from = selectedDate.toISOString().split("T")[0];
+      const to = from;
+      const res = await fetch(`/api/appointments?from=${from}&to=${to}`);
+  const data: UIAppointment[] = await res.json();
+
+      const slots: AvailableSlot[] = Array.from({ length: 10 }, (_, i) => {
+        const hour = 9 + i;
+        const time = `${hour.toString().padStart(2, "0")}:00`;
+        return {
+          time,
+          available: !data.some((a) => new Date(a.date).getHours() === hour),
+        };
+      });
+
+      setAvailableSlots(slots);
+    };
+
+    fetchSlots();
+  }, [selectedDate]);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
       updateAppointmentSchema.parse(form);
-      console.log("TESTE FORM: ", form);
       const method = appointment ? "PUT" : "POST";
       const url = appointment
         ? `/api/appointments/${appointment.id}`
         : "/api/appointments";
+
       await fetch(url, {
         method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...form, date: new Date(form.date) }),
       });
+
       onClose();
-    } catch (err: any) {
-      alert(err.message || "Erro ao salvar agendamento");
+    } catch (err) {
+      console.error(err);
+      alert("Erro ao salvar agendamento");
     }
   };
 
+  const handleSlotClick = (time: string) => {
+    if (!selectedDate) return;
+    const [hour, minute] = time.split(":").map(Number);
+    const dt = new Date(selectedDate);
+    dt.setHours(hour, minute, 0, 0);
+    setForm({ ...form, date: dt.toISOString().slice(0, 16) });
+    setSelectedSlot(time);
+  };
+
+  // Dados do gráfico
+  const chartData = {
+    labels: availableSlots.map((slot) => slot.time),
+    datasets: [
+      {
+        label: "Horários",
+        data: availableSlots.map(() => 1), // todas barras com mesma altura
+        backgroundColor: availableSlots.map(
+          (slot) =>
+            slot.time === selectedSlot
+              ? "#014e78" // selecionado
+              : slot.available
+              ? "#1ac897" // livre
+              : "#e0e0e0" // ocupado
+        ),
+        borderRadius: 6,
+        barThickness: 20,
+        hoverBackgroundColor: availableSlots.map(
+          (slot) =>
+            slot.time === selectedSlot
+              ? "#014e78" // destaque do selecionado ao passar o mouse
+              : slot.available
+              ? "#15a079" // destaque do livre
+              : "#a3a3a3" // destaque do ocupado
+        ),
+      },
+    ],
+  };
+
+  const chartOptions = {
+    indexAxis: "y" as const,
+    responsive: true,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: function (context: unknown) {
+            const idx = (context as { dataIndex?: number }).dataIndex ?? 0;
+            return availableSlots[idx]?.available ? "Livre" : "Ocupado";
+          },
+        },
+      },
+    },
+    scales: {
+      x: { display: false },
+      y: {
+        ticks: { color: "#111827", font: { size: 14 } },
+      },
+    },
+    onClick: (event: unknown, elements: unknown) => {
+      const els = elements as Array<{ index?: number }> | null;
+      if (els && els.length > 0) {
+        const index = els[0].index ?? 0;
+        const slot = availableSlots[index];
+        if (slot?.available) handleSlotClick(slot.time);
+      }
+    },
+  };
+
   return (
-    <div className="fixed inset-0 bg-black/75 flex justify-center items-center z-50">
+    <div className="fixed inset-0 bg-black/50 flex justify-center items-start z-50 pt-10 overflow-auto">
       <form
         onSubmit={handleSubmit}
-        className="bg-white p-6 rounded-lg shadow-md w-96 flex flex-col gap-3"
+        className="bg-white p-6 rounded-lg shadow-md w-full max-w-2xl flex flex-col gap-4"
       >
         <h2 className="text-xl text-text font-bold mb-2">
           {appointment ? "Editar Agendamento" : "Novo Agendamento"}
         </h2>
-        <Input
-          type="text"
-          placeholder="Nome do cliente"
-          value={form.clientName}
-          onChange={(e) => setForm({ ...form, clientName: e.target.value })}
-        />
-        <Input
-          type="text"
-          placeholder="Serviço"
-          value={form.service}
-          onChange={(e) => setForm({ ...form, service: e.target.value })}
-        />
-        <Input
-          type="number"
-          placeholder="Preço"
-          value={form.price}
-          onChange={(e) => setForm({ ...form, price: Number(e.target.value) })}
-        />
-        <Input
-          type="datetime-local"
-          value={form.date}
-          onChange={(e) => setForm({ ...form, date: e.target.value })}
-        />
-        <select
-          className="px-4 py-2 transition text-text-secondary focus:outline-none rounded-md border-2 border-gray-300 focus:border-primary"
-          value={form.status}
-          onChange={(e) => setForm({ ...form, status: e.target.value })}
-        >
-          <option value="PENDING">Pendente</option>
-          <option value="CONFIRMED">Confirmado</option>
-          <option value="COMPLETED">Concluído</option>
-          <option value="CANCELED">Cancelado</option>
-        </select>
-        <div className="flex justify-end gap-2 mt-2">
+
+        <div className="flex flex-col md:flex-row gap-4">
+          <div className="flex-1 flex flex-col gap-2">
+            <Input
+              type="text"
+              placeholder="Nome do cliente"
+              value={form.clientName}
+              onChange={(e) => setForm({ ...form, clientName: e.target.value })}
+            />
+            <Input
+              type="text"
+              placeholder="Serviço"
+              value={form.service}
+              onChange={(e) => setForm({ ...form, service: e.target.value })}
+            />
+            <Input
+              type="number"
+              placeholder="Preço"
+              value={form.price}
+              onChange={(e) =>
+                setForm({ ...form, price: Number(e.target.value) })
+              }
+            />
+            <select
+              className="px-4 py-2 mt-2 transition text-text-secondary focus:outline-none rounded-md border-2 border-gray-300 focus:border-primary w-full"
+              value={String(form.status)}
+              onChange={(e) => {
+                const val = e.target.value as AppointmentStatus;
+                if (Object.values(AppointmentStatus).includes(val)) {
+                  setForm({ ...form, status: val });
+                }
+              }}
+            >
+              {Object.values(AppointmentStatus).map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex-1 flex flex-col gap-2">
+            <Calendar
+              // react-calendar's onChange can be Date or Date[] (range). Normalize safely.
+              onChange={(value: Date | Date[] | unknown) => {
+                if (value instanceof Date) setSelectedDate(value);
+                else if (Array.isArray(value) && value[0] instanceof Date) setSelectedDate(value[0]);
+              }}
+              value={selectedDate}
+              className="rounded-lg shadow-sm"
+              tileClassName={({ date }) =>
+                date.toDateString() === new Date().toDateString()
+                  ? "bg-primary text-white"
+                  : ""
+              }
+            />
+            {selectedDate && availableSlots.length > 0 && (
+              <div className="mt-2 p-2 border rounded-lg shadow-inner bg-gray-50">
+                <p className="text-sm font-semibold mb-1">
+                  Horários disponíveis em {selectedDate.toLocaleDateString()}:
+                </p>
+                <Bar data={chartData} options={chartOptions} />
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 mt-4">
           <Button type="button" variant="outlined" size="sm" onClick={onClose}>
             Cancelar
           </Button>

--- a/src/app/(app)/dashboard/appointments/AppointmentList.tsx
+++ b/src/app/(app)/dashboard/appointments/AppointmentList.tsx
@@ -3,9 +3,11 @@
 
 import { Badge } from "@radix-ui/themes";
 
+import { UIAppointment } from "@/lib/appointments";
+
 interface Props {
-  appointments: any[];
-  onEdit: (appointment: any) => void;
+  appointments: UIAppointment[];
+  onEdit: (appointment: UIAppointment) => void;
   refresh: () => void;
 }
 

--- a/src/app/(app)/dashboard/appointments/new/page.tsx
+++ b/src/app/(app)/dashboard/appointments/new/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Calendar from "react-calendar";
+import "react-calendar/dist/Calendar.css";
+import Button from "@/app/components/ui/Button";
+import Input from "@/app/components/ui/Input";
+import Select from "@/app/components/ui/Select";
+import { z } from "zod";
+import { Appointment as PrismaAppointment } from "@/generated/prisma";
+import prismaToUI from '@/lib/appointments';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+const appointmentSchema = z.object({
+  clientName: z.string().min(1),
+  serviceId: z.string().min(1),
+  startTime: z.string().min(1),
+});
+
+// Interfaces
+// appointment server shape is read as Prisma Appointment and then normalized via `prismaToUI`
+
+interface Service {
+  id: string;
+  name: string;
+  duration: number;
+}
+
+interface AvailableSlot {
+  time: string;
+  available: boolean;
+}
+
+// Skeleton
+function Skeleton({ className }: { className: string }) {
+  return (
+    <div className={`animate-pulse bg-gray-200 rounded-md ${className}`} />
+  );
+}
+
+// Função para extrair payload do JWT
+function parseJwt(token: string) {
+  try {
+    return JSON.parse(atob(token.split(".")[1]));
+  } catch {
+    return null;
+  }
+}
+
+export default function NewAppointmentPage() {
+  const router = useRouter();
+  const [companyId, setCompanyId] = useState<string | null>(null);
+
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [services, setServices] = useState<Service[]>([]);
+  // local appointments are fetched and normalized below; no persistent state needed
+  const [form, setForm] = useState({
+    clientName: "",
+    serviceId: "",
+    startTime: "",
+  });
+
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [availableSlots, setAvailableSlots] = useState<AvailableSlot[]>([]);
+  const [selectedSlot, setSelectedSlot] = useState<string | null>(null);
+
+  const [loadingServices, setLoadingServices] = useState(false);
+  const [loadingSlots, setLoadingSlots] = useState(false);
+
+  // Pega companyId do JWT
+  useEffect(() => {
+    const token = localStorage.getItem("token"); // ou do cookie
+    if (!token) return;
+    const payload = parseJwt(token);
+    if (!payload?.companyId)
+      return console.error("CompanyId não encontrado no JWT");
+    setCompanyId(payload.companyId);
+  }, []);
+
+  // Fetch serviços
+  useEffect(() => {
+    console.log("Fetching services, companyId:", companyId);
+    if (!companyId) return;
+    console.log("companyId is null, skipping fetch");
+    setLoadingServices(true);
+    fetch(`/api/services?companyId=${companyId}`)
+      .then((res) => res.json())
+      .then((resData) => {
+        if (Array.isArray(resData.data)) setServices(resData.data);
+        else setServices([]);
+      })
+      .catch((err) => {
+        console.error("Erro ao buscar serviços:", err);
+        setServices([]);
+      })
+      .finally(() => setLoadingServices(false));
+  }, [companyId]);
+
+  // Fetch appointments e gera slots
+  useEffect(() => {
+    if (!selectedDate || !form.serviceId || !companyId) return;
+
+    const selectedService = services.find((s) => s.id === form.serviceId);
+    if (!selectedService) return;
+
+    setLoadingSlots(true);
+
+    const fetchSlots = async () => {
+      const dateStr = selectedDate.toISOString().split("T")[0];
+
+      // Horários de funcionamento
+      const resHours = await fetch(
+        `/api/companies/${companyId}/working-hours?date=${dateStr}`
+      );
+      const workingHours: { start: string; end: string }[] =
+        await resHours.json();
+
+      // Agendamentos existentes
+      const resAppointments = await fetch(
+        `/api/appointments?companyId=${companyId}&from=${dateStr}&to=${dateStr}`
+      );
+      const raw = await resAppointments.json();
+      // normalize server appointments to UI-friendly shape
+      const data = Array.isArray(raw)
+        ? (raw as PrismaAppointment[])
+            .map((r) => prismaToUI(r))
+            .filter((x): x is NonNullable<typeof x> => Boolean(x))
+        : [];
+
+      // Gera slots
+      const slots: AvailableSlot[] = [];
+
+          workingHours.forEach((wh) => {
+        const [startHour, startMinute] = wh.start.split(":").map(Number);
+        const [endHour, endMinute] = wh.end.split(":").map(Number);
+
+        const start = new Date(selectedDate);
+        start.setHours(startHour, startMinute, 0, 0);
+
+        const end = new Date(selectedDate);
+        end.setHours(endHour, endMinute, 0, 0);
+
+        const current = new Date(start);
+
+        while (current.getTime() + selectedService.duration * 60_000 <= end.getTime()) {
+          const timeStr = current.toTimeString().slice(0, 5);
+          const isOccupied = data.some((appt) => {
+            // `data` items are UI-normalized (have `date` and derived duration)
+            const apptStart = new Date(appt.date);
+            const apptEnd = new Date(appt.date);
+            apptEnd.setMinutes(apptEnd.getMinutes() + (services.find((s) => s.id === appt.serviceId)?.duration ?? selectedService.duration));
+            return !(
+              current.getTime() + selectedService.duration * 60_000 <= apptStart.getTime() || current.getTime() >= apptEnd.getTime()
+            );
+          });
+          slots.push({ time: timeStr, available: !isOccupied });
+          current.setMinutes(current.getMinutes() + selectedService.duration);
+        }
+      });
+
+      setAvailableSlots(slots);
+      setLoadingSlots(false);
+    };
+
+    fetchSlots();
+  }, [selectedDate, form.serviceId, services, companyId]);
+
+  const handleSlotClick = (time: string) => {
+    if (!selectedDate || !form.serviceId) return;
+
+    const [hour, minute] = time.split(":").map(Number);
+    const dt = new Date(selectedDate);
+    dt.setHours(hour, minute, 0, 0);
+
+    setForm({ ...form, startTime: dt.toISOString() });
+    setSelectedSlot(time);
+    setStep(3);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      appointmentSchema.parse(form);
+      if (!companyId) throw new Error("CompanyId não encontrado");
+
+      await fetch("/api/appointments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...form, companyId }),
+      });
+
+      router.push("/dashboard/appointments");
+    } catch (err) {
+      console.error(err);
+      alert("Erro ao criar agendamento");
+    }
+  };
+
+  const isSaveDisabled =
+    !selectedSlot ||
+    !availableSlots.find((s) => s.time === selectedSlot)?.available;
+
+  return (
+    <div className="flex flex-col items-center min-h-[calc(100vh-200px)]">
+      <h1 className="text-2xl font-bold mb-2">Novo Agendamento</h1>
+
+      {step === 1 && (
+        <div className="w-full max-w-2xl flex flex-col items-center">
+          <p className="text-md font-semibold mb-1 text-center">
+            Escolha a data do agendamento
+          </p>
+          <Calendar
+            onChange={(date: unknown) => {
+              setSelectedDate(date as Date);
+              setStep(2);
+            }}
+            value={selectedDate}
+            minDate={new Date()}
+            className="w-full rounded-lg! border-2! border-gray-300! p-2!"
+          />
+        </div>
+      )}
+
+      {step === 2 && selectedDate && (
+        <div className="w-full max-w-2xl flex flex-col items-center gap-4">
+          <Select
+            placeholder="Selecione um serviço"
+            value={form.serviceId}
+            onChange={(value) => setForm({ ...form, serviceId: value })}
+            options={services.map((s) => ({ label: s.name, value: s.id }))}
+            disabled={loadingServices}
+          />
+
+          {form.serviceId ? (
+            loadingSlots ? (
+              <Skeleton className="h-[400px] w-full" />
+            ) : (
+              <div className="h-[400px] w-full">
+                <Bar
+                  data={{
+                    labels: availableSlots.map((slot) => slot.time),
+                    datasets: [
+                      {
+                        label: "Horários",
+                        data: availableSlots.map(() => 1),
+                        backgroundColor: availableSlots.map((slot, i) => {
+                          if (!form.serviceId) return "#e0e0e0";
+                          if (selectedSlot) {
+                            const startIndex = availableSlots.findIndex(
+                              (s) => s.time === selectedSlot
+                            );
+                            const durationSlots = Math.ceil(
+                              (services.find((s) => s.id === form.serviceId)
+                                ?.duration ?? 0) / 30
+                            );
+                            if (
+                              i >= startIndex &&
+                              i < startIndex + durationSlots
+                            )
+                              return "#1ac897";
+                          }
+                          return slot.available ? "#b1f0dc" : "#e0e0e0";
+                        }),
+                        borderRadius: 6,
+                        barThickness: 20,
+                      },
+                    ],
+                  }}
+                  options={{
+                    indexAxis: "y" as const,
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: { legend: { display: false } },
+                    onClick: (event, elements) => {
+                      if (elements.length > 0) {
+                        const index = elements[0].index;
+                        const slot = availableSlots[index];
+                        if (slot.available) handleSlotClick(slot.time);
+                      }
+                    },
+                  }}
+                />
+              </div>
+            )
+          ) : (
+            <p className="text-gray-500">
+              Selecione um serviço para ver os horários disponíveis.
+            </p>
+          )}
+
+          <div className="flex justify-center mt-1 gap-2">
+            <Button onClick={() => setStep(1)} variant="outlined" size="sm">
+              Voltar
+            </Button>
+            {form.serviceId && (
+              <Button
+                onClick={() => setStep(3)}
+                variant="outlined"
+                size="sm"
+                disabled={!selectedSlot}
+              >
+                Próximo
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {step === 3 && (
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white p-6 rounded-lg shadow-md w-full max-w-lg flex flex-col gap-4"
+        >
+          <Input
+            type="text"
+            placeholder="Nome do cliente"
+            value={form.clientName}
+            onChange={(e) => setForm({ ...form, clientName: e.target.value })}
+          />
+
+          <Select
+            placeholder="Selecione um serviço"
+            value={form.serviceId}
+            onChange={(value) => setForm({ ...form, serviceId: value })}
+            options={services.map((s) => ({ label: s.name, value: s.id }))}
+            disabled={loadingServices}
+          />
+
+          <div className="flex justify-between mt-4">
+            <Button onClick={() => setStep(2)} type="button" variant="outlined">
+              Voltar
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSaveDisabled}
+              className="disabled:opacity-50"
+            >
+              Salvar
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/company/CompanyTabs.tsx
+++ b/src/app/(app)/dashboard/company/CompanyTabs.tsx
@@ -1,9 +1,13 @@
-// app/company/CompanyTabs.tsx
 "use client";
 
 import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import CompanyForm from "./CompanyForm";
+import WorkingHoursForm from "./WorkingHoursForm";
+import ServicesForm from "./ServicesForm";
 import { JWTPayload } from "@/app/libs/auth";
+import { fadeInDirection } from "@/animations/motionVariants";
+import ProfessionalServiceForm from "./ProsefessionalServiceForm";
 
 interface CompanyTabsProps {
   company: {
@@ -20,37 +24,37 @@ interface CompanyTabsProps {
 }
 
 export default function CompanyTabs({ company, user }: CompanyTabsProps) {
-  const [tab, setTab] = useState<"info" | "edit">("info");
+  const [tab, setTab] = useState<"info" | "edit" | "config">("info");
+  const [configTab, setConfigTab] = useState<
+    "workingHours" | "services" | "professionalServices"
+  >("workingHours");
 
   return (
     <div className="flex flex-col md:flex-row gap-8">
       {/* Subnavegação lateral */}
       <nav className="md:w-1/4 bg-white rounded-lg shadow p-4 flex flex-col gap-2">
-        <button
-          className={`p-2 rounded transition-colors duration-300 hover:bg-background-muted hover:text-primary ${
-            tab === "info"
-              ? "bg-background-muted font-semibold text-primary font-bold"
-              : "text-text"
-          }`}
-          onClick={() => setTab("info")}
-        >
-          Informações
-        </button>
-        <button
-          className={`p-2 rounded transition-colors duration-300 hover:bg-background-muted hover:text-primary ${
-            tab === "edit"
-              ? "bg-background-muted font-semibold text-primary font-bold"
-              : "text-text"
-          }`}
-          onClick={() => setTab("edit")}
-        >
-          Editar Empresa
-        </button>
+        {["info", "edit", "config"].map((t) => (
+          <button
+            key={t}
+            className={`p-2 rounded transition-colors duration-300 hover:bg-background-muted hover:text-primary ${
+              tab === t
+                ? "bg-background-muted font-semibold text-primary"
+                : "text-text"
+            }`}
+            onClick={() => setTab(t as "info" | "edit" | "config")}
+          >
+            {t === "info"
+              ? "Informações"
+              : t === "edit"
+              ? "Editar Empresa"
+              : "Configurações"}
+          </button>
+        ))}
       </nav>
 
       {/* Conteúdo da aba */}
-      <div className="md:w-3/4 bg-white rounded-lg shadow p-6">
-        {tab === "info" ? (
+      <div className="md:w-3/4 bg-white rounded-lg shadow p-6 flex flex-col gap-6">
+        {tab === "info" && (
           <div className="flex flex-col gap-4">
             <h2 className="text-xl font-bold text-text">
               Informações da Empresa
@@ -85,8 +89,85 @@ export default function CompanyTabs({ company, user }: CompanyTabsProps) {
               <strong>Plano:</strong> {company.contrato}
             </p>
           </div>
-        ) : (
-          <CompanyForm user={user} />
+        )}
+
+        {tab === "edit" && <CompanyForm user={user} />}
+
+        {tab === "config" && (
+          <div className="flex flex-col gap-4">
+            {/* Sub-abas */}
+            <div className="flex gap-2 border-b pb-2">
+              <button
+                className={`px-4 py-2 rounded-t transition-colors duration-300 ${
+                  configTab === "workingHours"
+                    ? "bg-background-muted font-semibold text-primary border border-b-0 rounded-t-lg"
+                    : "text-text hover:bg-background-muted"
+                }`}
+                onClick={() => setConfigTab("workingHours")}
+              >
+                Horários de Funcionamento
+              </button>
+              <button
+                className={`px-4 py-2 rounded-t transition-colors duration-300 ${
+                  configTab === "services"
+                    ? "bg-background-muted font-semibold text-primary border border-b-0 rounded-t-lg"
+                    : "text-text hover:bg-background-muted"
+                }`}
+                onClick={() => setConfigTab("services")}
+              >
+                Serviços
+              </button>
+              <button
+                className={`px-4 py-2 rounded-t transition-colors duration-300 ${
+                  configTab === "professionalServices"
+                    ? "bg-background-muted font-semibold text-primary border border-b-0 rounded-t-lg"
+                    : "text-text hover:bg-background-muted"
+                }`}
+                onClick={() => setConfigTab("professionalServices")}
+              >
+                Serviços por Profissional
+              </button>
+            </div>
+
+            {/* Conteúdo das sub-abas animado */}
+            <div className="bg-white p-4 rounded-lg shadow min-h-[300px]">
+              <AnimatePresence mode="wait">
+                {configTab === "workingHours" && (
+                  <motion.div
+                    key="workingHours"
+                    variants={fadeInDirection("right", 20)}
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                  >
+                    <WorkingHoursForm companyId={company.id} />
+                  </motion.div>
+                )}
+                {configTab === "services" && (
+                  <motion.div
+                    key="services"
+                    variants={fadeInDirection("left", 20)}
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                  >
+                    <ServicesForm companyId={company.id} />
+                  </motion.div>
+                )}
+                {configTab === "professionalServices" && (
+                  <motion.div
+                    key="professionalServices"
+                    variants={fadeInDirection("up", 20)}
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                  >
+                    <ProfessionalServiceForm companyId={company.id} />
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/src/app/(app)/dashboard/company/ProsefessionalServiceForm.tsx
+++ b/src/app/(app)/dashboard/company/ProsefessionalServiceForm.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import Button from "@/app/components/ui/Button";
+import { useToast } from "@/app/components/ui/ToastErrorProvider";
+
+interface Professional {
+  id: string;
+  name: string;
+}
+
+interface Service {
+  id: string;
+  name: string;
+}
+
+interface ProfessionalService {
+  id: string;
+  professionalId: string;
+  serviceId: string;
+  service: Service;
+  professional: Professional;
+}
+
+interface Props {
+  companyId: string;
+}
+
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorDetails?: { path?: string; message: string }[];
+}
+
+export default function ProfessionalServiceForm({ companyId }: Props) {
+  const [professionals, setProfessionals] = useState<Professional[]>([]);
+  const [services, setServices] = useState<Service[]>([]);
+  const [associations, setAssociations] = useState<ProfessionalService[]>([]);
+  const [filteredAssociations, setFilteredAssociations] = useState<
+    ProfessionalService[]
+  >([]);
+  const [newAssoc, setNewAssoc] = useState<{
+    professionalId: string;
+    serviceId: string;
+  }>({
+    professionalId: "",
+    serviceId: "",
+  });
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [filterProfessionalId, setFilterProfessionalId] = useState<string>("");
+  const [filterServiceName, setFilterServiceName] = useState<string>("");
+
+  const toast = useToast();
+  const debounceTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  // Fetch dados
+  const fetchProfessionals = async () => {
+    try {
+      const res = await fetch(`/api/company/${companyId}/professionals`);
+      const data: ApiResponse<Professional[]> = await res.json();
+      if (data.success && data.data) setProfessionals(data.data);
+    } catch (err) {
+      toast(
+        (err as Error).message || "Erro ao carregar profissionais",
+        "error"
+      );
+    }
+  };
+
+  const fetchServices = async () => {
+    try {
+      const res = await fetch(`/api/services?companyId=${companyId}`);
+      const data: ApiResponse<Service[]> = await res.json();
+      if (data.success && data.data) setServices(data.data);
+    } catch (err) {
+      toast((err as Error).message || "Erro ao carregar serviços", "error");
+    }
+  };
+
+  const fetchAssociations = async () => {
+    try {
+      const url = filterProfessionalId
+        ? `/api/professional-service?professionalId=${filterProfessionalId}`
+        : `/api/professional-service?companyId=${companyId}`; // <- usa companyId quando não tiver filtro
+
+      const res = await fetch(url);
+      const data: ApiResponse<ProfessionalService[]> = await res.json();
+
+      if (data.success && data.data) {
+        setAssociations(data.data);
+        setFilteredAssociations(data.data);
+      }
+    } catch (err) {
+      toast((err as Error).message || "Erro ao carregar associações", "error");
+    }
+  };
+
+  useEffect(() => {
+    fetchProfessionals();
+    fetchServices();
+    fetchAssociations();
+  }, [companyId, filterProfessionalId]);
+
+  // Debounce na pesquisa
+  useEffect(() => {
+    if (debounceTimeout.current) clearTimeout(debounceTimeout.current);
+
+    debounceTimeout.current = setTimeout(() => {
+      let filtered = associations;
+      if (filterProfessionalId) {
+        filtered = filtered.filter(
+          (a) => a.professionalId === filterProfessionalId
+        );
+      }
+      if (filterServiceName) {
+        filtered = filtered.filter((a) =>
+          a.service.name.toLowerCase().includes(filterServiceName.toLowerCase())
+        );
+      }
+      setFilteredAssociations(filtered);
+    }, 300); // 300ms debounce
+  }, [filterProfessionalId, filterServiceName, associations]);
+
+  // CRUD
+  const handleSave = async () => {
+    if (!newAssoc.professionalId || !newAssoc.serviceId) {
+      toast("Selecione profissional e serviço", "error");
+      return;
+    }
+    setSavingId("new");
+
+    try {
+      const res = await fetch(`/api/professional-service`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newAssoc),
+      });
+      const data: ApiResponse<ProfessionalService> = await res.json();
+
+      if (!data.success) {
+        if (Array.isArray(data.errorDetails)) {
+          data.errorDetails.forEach((err) =>
+            toast(`${err.path}: ${err.message}`, "error")
+          );
+        } else {
+          toast(data.error || "Erro ao salvar associação", "error");
+        }
+        return;
+      }
+
+      setNewAssoc({ professionalId: "", serviceId: "" });
+      fetchAssociations();
+      toast("Associação criada com sucesso!", "success");
+    } catch (err) {
+      toast((err as Error).message || "Erro desconhecido", "error");
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id);
+    try {
+      const res = await fetch(`/api/professional-service/${id}`, {
+        method: "DELETE",
+      });
+      const data: ApiResponse<void> = await res.json();
+      if (!data.success)
+        throw new Error(data.error || "Erro ao deletar associação");
+
+      fetchAssociations();
+      toast("Associação removida com sucesso!", "success");
+    } catch (err) {
+      toast((err as Error).message || "Erro desconhecido", "error");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h3 className="text-lg font-bold">Serviços por Profissional</h3>
+
+      {/* Formulário de nova associação */}
+      <div className="flex gap-2 items-center">
+        <select
+          className="p-2 border rounded"
+          value={newAssoc.professionalId}
+          onChange={(e) =>
+            setNewAssoc({ ...newAssoc, professionalId: e.target.value })
+          }
+        >
+          <option value="">Selecione um profissional</option>
+          {professionals.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          className="p-2 border rounded"
+          value={newAssoc.serviceId}
+          onChange={(e) =>
+            setNewAssoc({ ...newAssoc, serviceId: e.target.value })
+          }
+        >
+          <option value="">Selecione um serviço</option>
+          {services.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={savingId === "new"}
+          loading={savingId === "new"}
+        >
+          Adicionar
+        </Button>
+      </div>
+
+      {/* Filtros */}
+      <div className="flex gap-2 items-center">
+        <select
+          className="p-2 border rounded"
+          value={filterProfessionalId}
+          onChange={(e) => setFilterProfessionalId(e.target.value)}
+        >
+          <option value="">Filtrar por profissional</option>
+          {professionals.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+
+        <input
+          type="text"
+          className="p-2 border rounded"
+          placeholder="Pesquisar serviço..."
+          value={filterServiceName}
+          onChange={(e) => setFilterServiceName(e.target.value)}
+        />
+      </div>
+
+      {/* Tabela */}
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border px-2 py-1">Profissional</th>
+              <th className="border px-2 py-1">Serviço</th>
+              <th className="border px-2 py-1">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredAssociations.map((assoc) => (
+              <tr key={assoc.id} className="hover:bg-gray-50">
+                <td className="border px-2 py-1">
+                  {assoc.professional?.name || "-"}
+                </td>
+                <td className="border px-2 py-1">
+                  {assoc.service?.name || "-"}
+                </td>
+                <td className="border px-2 py-1">
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => handleDelete(assoc.id)}
+                    disabled={deletingId === assoc.id}
+                    loading={deletingId === assoc.id}
+                  >
+                    Remover
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/company/ServicesForm.tsx
+++ b/src/app/(app)/dashboard/company/ServicesForm.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Input from "@/app/components/ui/Input";
+import Button from "@/app/components/ui/Button";
+import { useToast } from "@/app/components/ui/ToastErrorProvider";
+import Modal from "@/app/components/ui/Modal";
+
+interface Service {
+  id: string;
+  name: string;
+  price: number;
+  duration: number;
+}
+
+interface Props {
+  companyId: string;
+}
+
+interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorDetails?: { path?: string | string[]; message: string }[];
+}
+
+export default function ServicesForm({ companyId }: Props) {
+  const [services, setServices] = useState<Service[]>([]);
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Service | null>(null);
+  const [newService, setNewService] = useState<Omit<Service, "id">>({
+    name: "",
+    price: 0,
+    duration: 0,
+  });
+
+  const showToast = useToast();
+
+  const fetchServices = async () => {
+    try {
+      const res = await fetch(`/api/services?companyId=${companyId}`);
+      const data: ApiResponse<Service[]> = await res.json();
+      if (data.success && data.data) {
+        setServices(data.data);
+      }
+    } catch {
+      showToast("Erro ao carregar serviços", "error");
+    }
+  };
+
+  useEffect(() => {
+    fetchServices();
+  }, [companyId]);
+
+  const handleSave = async (service?: Service) => {
+    const id = service?.id || "new";
+    setSavingId(id);
+
+    try {
+      const payload = service ? service : { ...newService, companyId };
+      const res = await fetch(
+        service ? `/api/services/${service.id}` : "/api/services",
+        {
+          method: service ? "PUT" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }
+      );
+
+      const data: ApiResponse<Service> = await res.json();
+      if (!data.success) {
+        if (Array.isArray(data.errorDetails)) {
+          data.errorDetails.forEach((err) => {
+            const path = Array.isArray(err.path)
+              ? err.path.join(".")
+              : err.path ?? "";
+            showToast(path ? `${path}: ${err.message}` : err.message, "error");
+          });
+        } else {
+          showToast(data.error || "Erro ao salvar serviço", "error");
+        }
+      } else {
+        setNewService({ name: "", price: 0, duration: 0 });
+        await fetchServices();
+        showToast("Serviço salvo com sucesso!", "success");
+      }
+    } catch (err) {
+      showToast(
+        err instanceof Error
+          ? err.message
+          : "Erro desconhecido ao salvar serviço",
+        "error"
+      );
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    const id = deleteTarget.id;
+
+    setDeletingId(id);
+    try {
+      const res = await fetch(`/api/services/${id}`, { method: "DELETE" });
+      const data: ApiResponse = await res.json();
+
+      if (!data.success) {
+        throw new Error(data.error || "Erro ao deletar serviço");
+      }
+
+      await fetchServices();
+      showToast("Serviço excluído com sucesso!", "success");
+      setDeleteTarget(null);
+    } catch (err) {
+      showToast(
+        err instanceof Error
+          ? err.message
+          : "Erro desconhecido ao deletar serviço",
+        "error"
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h3 className="text-lg font-bold">Serviços</h3>
+
+      <div className="flex flex-col gap-2">
+        {services.map((service) => (
+          <div
+            key={service.id}
+            className="flex items-center gap-2 bg-gray-50 p-2 rounded"
+          >
+            <Input
+              value={service.name}
+              onChange={(e) =>
+                setServices((prev) =>
+                  prev.map((s) =>
+                    s.id === service.id ? { ...s, name: e.target.value } : s
+                  )
+                )
+              }
+              placeholder="Nome do serviço"
+            />
+            <Input
+              type="number"
+              value={service.price}
+              onChange={(e) =>
+                setServices((prev) =>
+                  prev.map((s) =>
+                    s.id === service.id
+                      ? { ...s, price: Number(e.target.value) }
+                      : s
+                  )
+                )
+              }
+              placeholder="Preço"
+            />
+            <Input
+              type="number"
+              value={service.duration}
+              onChange={(e) =>
+                setServices((prev) =>
+                  prev.map((s) =>
+                    s.id === service.id
+                      ? { ...s, duration: Number(e.target.value) }
+                      : s
+                  )
+                )
+              }
+              placeholder="Duração (min)"
+            />
+            <Button
+              size="sm"
+              onClick={() => handleSave(service)}
+              disabled={savingId === service.id}
+              loading={savingId === service.id}
+            >
+              Salvar
+            </Button>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => setDeleteTarget(service)}
+              disabled={deletingId === service.id}
+              loading={deletingId === service.id}
+            >
+              Excluir
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {/* Novo serviço */}
+      <div className="flex items-center gap-2 bg-white p-2 rounded shadow-sm">
+        <Input
+          value={newService.name}
+          onChange={(e) =>
+            setNewService({ ...newService, name: e.target.value })
+          }
+          placeholder="Nome do serviço"
+        />
+        <Input
+          type="number"
+          value={newService.price}
+          onChange={(e) =>
+            setNewService({ ...newService, price: Number(e.target.value) })
+          }
+          placeholder="Preço"
+        />
+        <Input
+          type="number"
+          value={newService.duration}
+          onChange={(e) =>
+            setNewService({ ...newService, duration: Number(e.target.value) })
+          }
+          placeholder="Duração (min)"
+        />
+        <Button
+          size="sm"
+          onClick={() => handleSave()}
+          disabled={savingId === "new"}
+          loading={savingId === "new"}
+        >
+          Adicionar
+        </Button>
+      </div>
+
+      {/* Modal de confirmação */}
+      <Modal
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        title="Confirmar exclusão"
+      >
+        <p className="mb-4">
+          Tem certeza que deseja excluir o serviço{" "}
+          <span className="font-semibold">{deleteTarget?.name}</span>?
+        </p>
+
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setDeleteTarget(null)}
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={confirmDelete}
+            loading={deletingId === deleteTarget?.id}
+          >
+            Excluir
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/company/WorkingHoursForm.tsx
+++ b/src/app/(app)/dashboard/company/WorkingHoursForm.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Input from "@/app/components/ui/Input";
+import Button from "@/app/components/ui/Button";
+import Modal from "@/app/components/ui/Modal";
+import { useToast } from "@/app/components/ui/ToastErrorProvider";
+
+interface WorkingHour {
+  id: string;
+  dayOfWeek: number;
+  openTime: string;
+  closeTime: string;
+}
+
+interface Props {
+  companyId: string;
+}
+
+interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorDetails?: { path?: string | string[]; message: string }[];
+}
+
+export default function WorkingHoursForm({ companyId }: Props) {
+  const [hours, setHours] = useState<WorkingHour[]>([]);
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<WorkingHour | null>(null);
+  const [newHour, setNewHour] = useState<Omit<WorkingHour, "id">>({
+    dayOfWeek: 0,
+    openTime: "",
+    closeTime: "",
+  });
+
+  const showToast = useToast();
+  const daysOfWeek = [
+    "Domingo",
+    "Segunda",
+    "Terça",
+    "Quarta",
+    "Quinta",
+    "Sexta",
+    "Sábado",
+  ];
+
+  const fetchHours = async () => {
+    try {
+      const res = await fetch(`/api/working-hours?companyId=${companyId}`);
+      const data: ApiResponse<WorkingHour[]> = await res.json();
+      if (data.success && data.data) setHours(data.data);
+    } catch {
+      showToast("Erro ao carregar horários", "error");
+    }
+  };
+
+  useEffect(() => {
+    fetchHours();
+  }, [companyId]);
+
+  const handleSave = async (hour?: WorkingHour) => {
+    const id = hour?.id || "new";
+    setSavingId(id);
+
+    try {
+      const payload = hour ? hour : { ...newHour, companyId };
+      const res = await fetch(
+        hour ? `/api/working-hours/${hour.id}` : "/api/working-hours",
+        {
+          method: hour ? "PUT" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }
+      );
+      const data: ApiResponse<WorkingHour> = await res.json();
+
+      if (!data.success) {
+        if (Array.isArray(data.errorDetails)) {
+          data.errorDetails.forEach((err) => {
+            const path = Array.isArray(err.path)
+              ? err.path.join(".")
+              : err.path ?? "";
+            showToast(path ? `${path}: ${err.message}` : err.message, "error");
+          });
+        } else {
+          showToast(data.error || "Erro ao salvar horário", "error");
+        }
+        return;
+      }
+
+      setNewHour({ dayOfWeek: 0, openTime: "", closeTime: "" });
+      await fetchHours();
+      showToast("Horário salvo com sucesso!", "success");
+    } catch (err) {
+      const error = err as Error;
+      showToast(
+        error.message || "Erro desconhecido ao salvar horário",
+        "error"
+      );
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+
+    setDeletingId(deleteTarget.id);
+    try {
+      const res = await fetch(`/api/working-hours/${deleteTarget.id}`, {
+        method: "DELETE",
+      });
+      const data: ApiResponse = await res.json();
+
+      if (!data.success)
+        throw new Error(data.error || "Erro ao deletar horário");
+
+      await fetchHours();
+      showToast("Horário excluído com sucesso!", "success");
+      setDeleteTarget(null);
+    } catch (err) {
+      const error = err as Error;
+      showToast(
+        error.message || "Erro desconhecido ao deletar horário",
+        "error"
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h3 className="text-lg font-bold">Horários de Funcionamento</h3>
+
+      {/* Lista de horários */}
+      <div className="flex flex-col gap-2">
+        {hours.map((hour) => (
+          <div
+            key={hour.id}
+            className="flex items-center gap-2 bg-gray-50 p-2 rounded"
+          >
+            <select
+              value={hour.dayOfWeek}
+              onChange={(e) =>
+                setHours((prev) =>
+                  prev.map((h) =>
+                    h.id === hour.id
+                      ? { ...h, dayOfWeek: Number(e.target.value) }
+                      : h
+                  )
+                )
+              }
+            >
+              {daysOfWeek.map((day, i) => (
+                <option key={i} value={i}>
+                  {day}
+                </option>
+              ))}
+            </select>
+
+            <Input
+              type="time"
+              value={hour.openTime}
+              onChange={(e) =>
+                setHours((prev) =>
+                  prev.map((h) =>
+                    h.id === hour.id ? { ...h, openTime: e.target.value } : h
+                  )
+                )
+              }
+            />
+            <Input
+              type="time"
+              value={hour.closeTime}
+              onChange={(e) =>
+                setHours((prev) =>
+                  prev.map((h) =>
+                    h.id === hour.id ? { ...h, closeTime: e.target.value } : h
+                  )
+                )
+              }
+            />
+
+            <Button
+              size="sm"
+              onClick={() => handleSave(hour)}
+              disabled={savingId === hour.id}
+              loading={savingId === hour.id}
+            >
+              Salvar
+            </Button>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => setDeleteTarget(hour)}
+              disabled={deletingId === hour.id}
+              loading={deletingId === hour.id}
+            >
+              Excluir
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {/* Novo horário */}
+      <div className="flex items-center gap-2 bg-white p-2 rounded shadow-sm">
+        <select
+          value={newHour.dayOfWeek}
+          onChange={(e) =>
+            setNewHour({ ...newHour, dayOfWeek: Number(e.target.value) })
+          }
+        >
+          {daysOfWeek.map((day, i) => (
+            <option key={i} value={i}>
+              {day}
+            </option>
+          ))}
+        </select>
+        <Input
+          type="time"
+          value={newHour.openTime}
+          onChange={(e) => setNewHour({ ...newHour, openTime: e.target.value })}
+        />
+        <Input
+          type="time"
+          value={newHour.closeTime}
+          onChange={(e) =>
+            setNewHour({ ...newHour, closeTime: e.target.value })
+          }
+        />
+        <Button
+          size="sm"
+          onClick={() => handleSave()}
+          disabled={savingId === "new"}
+          loading={savingId === "new"}
+        >
+          Adicionar
+        </Button>
+      </div>
+
+      {/* Modal de confirmação */}
+      <Modal
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        title="Confirmar exclusão"
+      >
+        <p className="mb-4">
+          Tem certeza que deseja excluir o horário de{" "}
+          <span className="font-semibold">
+            {deleteTarget ? daysOfWeek[deleteTarget.dayOfWeek] : ""}
+          </span>
+          ?
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setDeleteTarget(null)}
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={confirmDelete}
+            loading={deletingId === deleteTarget?.id}
+          >
+            Excluir
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import Sidebar from "./components/Sidebar";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import { ToastProvider } from "@/app/components/ui/ToastErrorProvider";
 
 export default async function DashboardLayout({
   children,
@@ -13,14 +14,16 @@ export default async function DashboardLayout({
   if (!user) redirect("/auth");
 
   return (
-    <div className="flex min-h-screen bg-gray-100">
-      <Sidebar />
+    <ToastProvider>
+      <div className="flex min-h-screen bg-gray-100">
+        <Sidebar />
 
-      <div className="flex flex-col flex-1">
-        <Header user={user} />
-        <main className="flex-1 p-6">{children}</main>
-        <Footer />
+        <div className="flex flex-col flex-1">
+          <Header user={user} />
+          <main className="flex-1 p-6">{children}</main>
+          <Footer />
+        </div>
       </div>
-    </div>
+    </ToastProvider>
   );
 }

--- a/src/app/api/appointments/by/route.ts
+++ b/src/app/api/appointments/by/route.ts
@@ -1,0 +1,58 @@
+// app/api/appointments/by/route.ts
+
+import { getUserFromCookie } from "@/app/libs/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { startOfDay, endOfDay } from "date-fns";
+
+import prisma from "@/lib/prisma";
+
+function parseLocalDate(dateStr: string): Date {
+  // Trata "YYYY-MM-DD" como data no timezone local
+  const [year, month, day] = dateStr.split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
+export async function GET(req: NextRequest) {
+  const user = await getUserFromCookie();
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(req.url);
+  const date = url.searchParams.get("date");
+  console.log("URL: ", url, "date param: ", date);
+
+  try {
+    let parsedDate: Date | null = null;
+
+    if (date) {
+      // Se for só "YYYY-MM-DD", parseia corretamente como local
+      if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        parsedDate = parseLocalDate(date);
+      } else {
+        // Se vier ISO completo, usa direto
+        parsedDate = new Date(date);
+      }
+    }
+
+    const appointments = await prisma.appointment.findMany({
+      where: {
+        professionalId: user.id,
+        ...(parsedDate && {
+          startTime: {
+            gte: startOfDay(parsedDate),
+            lte: endOfDay(parsedDate),
+          },
+        }),
+      },
+      orderBy: { startTime: "desc" },
+    });
+
+    return NextResponse.json(appointments);
+  } catch (error: unknown) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Erro ao buscar agendamentos" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -1,95 +1,319 @@
-// app/api/appointments/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient, AppointmentStatus } from "@/generated/prisma";
-import { getUserFromCookie } from "@/app/libs/auth";
-import { z } from "zod";
+import { z, ZodError } from "zod";
+import prisma from "@/lib/prisma";
 
-const prisma = new PrismaClient();
+// Tipagem ApiResponse
+interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorDetails?: { path?: string; message: string }[];
+}
+
+// -------------------
+// Schemas de validação
+// -------------------
 
 const createAppointmentSchema = z.object({
+  companyId: z.string().min(1),
+  professionalId: z.string().min(1),
   clientName: z.string().min(1),
-  service: z.string().min(1),
-  price: z.number().optional(),
-  date: z.string(), // ISO string
-  status: z.nativeEnum(AppointmentStatus).optional(),
+  serviceId: z.string().min(1),
+  startTime: z.string().refine((s) => !Number.isNaN(Date.parse(s)), {
+    message: "startTime deve ser uma ISO date válida",
+  }),
 });
 
-type CreateAppointmentInput = z.infer<typeof createAppointmentSchema>;
+const updateAppointmentSchema = z.object({
+  startTime: z
+    .string()
+    .optional()
+    .refine((s) => !s || !Number.isNaN(Date.parse(s)), {
+      message: "startTime deve ser uma ISO date válida",
+    }),
+  serviceId: z.string().optional(),
+  status: z.enum(["PENDING", "CONFIRMED", "COMPLETED", "CANCELED"]).optional(),
+});
+
+// -------------------
+// Helpers
+// -------------------
+
+function timeToMinutes(hhmm: string) {
+  const [hh, mm] = hhmm.split(":").map(Number);
+  return hh * 60 + mm;
+}
+
+function getDayOfWeekUTC(date: Date) {
+  return date.getUTCDay(); // 0..6
+}
+
+function hashToTwoInts(key: string): [number, number] {
+  let h = 5381;
+  for (let i = 0; i < key.length; i++) h = (h * 33) ^ key.charCodeAt(i);
+  const a = h >>> 0;
+  const b = ~h >>> 0;
+  return [a, b];
+}
+
+// -------------------
+// POST - criar appointment
+// -------------------
 
 export async function POST(req: NextRequest) {
-  const user = await getUserFromCookie();
-  if (!user)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  if (!user.companyId)
-    return NextResponse.json(
-      { error: "Empresa não vinculada" },
-      { status: 400 }
-    );
-
   try {
-    const body: unknown = await req.json();
-    const data: CreateAppointmentInput = createAppointmentSchema.parse(body);
-    console.log("DATA RECEBIDA: ", data);
+    const body = await req.json();
+    const parsed = createAppointmentSchema.parse(body);
+    const start = new Date(parsed.startTime);
 
-    const appointment = await prisma.appointment.create({
-      data: {
-        ...data,
-        date: new Date(data.date),
-        professionalId: user.id,
-        companyId: user.companyId,
-      },
+    const service = await prisma.service.findUnique({
+      where: { id: parsed.serviceId },
+      select: { id: true, duration: true, companyId: true },
+    });
+    if (!service || service.companyId !== parsed.companyId)
+      return NextResponse.json<ApiResponse>(
+        {
+          success: false,
+          error: "Serviço não encontrado ou não pertence à empresa",
+        },
+        { status: 400 }
+      );
+
+    const end = new Date(start.getTime() + service.duration * 60_000);
+
+    // Working hours
+    const day = getDayOfWeekUTC(start);
+    const wh = await prisma.workingHours.findFirst({
+      where: { companyId: parsed.companyId, dayOfWeek: day },
+    });
+    if (!wh)
+      return NextResponse.json<ApiResponse>(
+        {
+          success: false,
+          error: "Horário de funcionamento não configurado para esse dia",
+        },
+        { status: 400 }
+      );
+
+    const startMinutes = start.getUTCHours() * 60 + start.getUTCMinutes();
+    const endMinutes = end.getUTCHours() * 60 + end.getUTCMinutes();
+    if (
+      startMinutes < timeToMinutes(wh.openTime) ||
+      endMinutes > timeToMinutes(wh.closeTime)
+    ) {
+      return NextResponse.json<ApiResponse>(
+        {
+          success: false,
+          error: "Agendamento fora do horário de funcionamento",
+        },
+        { status: 400 }
+      );
+    }
+
+    const [lock1, lock2] = hashToTwoInts(parsed.professionalId);
+
+    const created = await prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(${lock1}, ${lock2})`;
+
+      const overlapCount = await tx.appointment.count({
+        where: {
+          professionalId: parsed.professionalId,
+          AND: [{ startTime: { lt: end } }, { endTime: { gt: start } }],
+        },
+      });
+
+      if (overlapCount > 0) {
+        throw new Error(
+          "Já existe agendamento conflitando para esse profissional nesse horário"
+        );
+      }
+
+      return await tx.appointment.create({
+        data: {
+          companyId: parsed.companyId,
+          professionalId: parsed.professionalId,
+          clientName: parsed.clientName,
+          serviceId: parsed.serviceId,
+          startTime: start,
+          endTime: end,
+        },
+      });
     });
 
-    return NextResponse.json(appointment, { status: 201 });
-  } catch (error: unknown) {
-    console.error(error);
-    if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: error.errors }, { status: 400 });
+    return NextResponse.json<ApiResponse>({ success: true, data: created });
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const errorDetails = err.issues.map((i) => ({
+        path: i.path.join("."),
+        message: i.message,
+      }));
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "Erro de validação", errorDetails },
+        { status: 400 }
+      );
     }
-    return NextResponse.json(
-      { error: "Erro ao criar agendamento" },
+    return NextResponse.json<ApiResponse>(
+      {
+        success: false,
+        error: (err as Error).message || "Erro ao criar agendamento",
+      },
       { status: 500 }
     );
   }
 }
 
+// -------------------
+// GET - listar appointments
+// -------------------
+
 export async function GET(req: NextRequest) {
-  const user = await getUserFromCookie();
-  if (!user)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  const url = new URL(req.url);
-  console.log("URL: ", url);
-
-  const status = url.searchParams.get("status") as
-    | AppointmentStatus
-    | undefined;
-  const from = url.searchParams.get("from");
-  const to = url.searchParams.get("to");
-
-  console.log("Filters - from:", from, "to:", to, "status:", status);
-
   try {
+    const { searchParams } = req.nextUrl;
+    const companyId = searchParams.get("companyId");
+    const professionalId = searchParams.get("professionalId");
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
+
+    if (!companyId)
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "companyId é obrigatório" },
+        { status: 400 }
+      );
+
+    const where: any = { companyId };
+    if (professionalId) where.professionalId = professionalId;
+    if (from || to) where.startTime = {};
+    if (from) where.startTime.gte = new Date(from);
+    if (to) where.startTime.lte = new Date(to);
+
     const appointments = await prisma.appointment.findMany({
-      where: {
-        professionalId: user.id,
-        ...(status && { status }),
-        ...(from &&
-          to && {
-            date: {
-              gte: new Date(from),
-              lt: new Date(new Date(to).getTime() + 24 * 60 * 60 * 1000),
-            },
-          }),
-      },
-      orderBy: { date: "desc" },
+      where,
+      include: { service: true, professional: true },
+      orderBy: { startTime: "asc" },
     });
 
-    return NextResponse.json(appointments);
-  } catch (error: unknown) {
-    console.error(error);
-    return NextResponse.json(
-      { error: "Erro ao buscar agendamentos" },
+    return NextResponse.json<ApiResponse>({
+      success: true,
+      data: appointments,
+    });
+  } catch (err) {
+    return NextResponse.json<ApiResponse>(
+      {
+        success: false,
+        error: (err as Error).message || "Erro ao listar agendamentos",
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// -------------------
+// PUT - atualizar appointment
+// -------------------
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { id, ...rest } = body;
+    if (!id)
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "id é obrigatório" },
+        { status: 400 }
+      );
+
+    const parsed = updateAppointmentSchema.parse(rest);
+
+    const current = await prisma.appointment.findUnique({ where: { id } });
+    if (!current)
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "Agendamento não encontrado" },
+        { status: 404 }
+      );
+
+    const start = parsed.startTime
+      ? new Date(parsed.startTime)
+      : current.startTime;
+    const serviceId = parsed.serviceId || current.serviceId;
+
+    const service = await prisma.service.findUnique({
+      where: { id: serviceId },
+      select: { duration: true, companyId: true },
+    });
+    if (!service)
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "Serviço inválido" },
+        { status: 400 }
+      );
+
+    const end = new Date(start.getTime() + service.duration * 60_000);
+
+    // same advisory lock + overlap check as POST
+    const [lock1, lock2] = hashToTwoInts(current.professionalId);
+
+    const updated = await prisma.$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(${lock1}, ${lock2})`;
+
+      const overlapCount = await tx.appointment.count({
+        where: {
+          professionalId: current.professionalId,
+          id: { not: id },
+          AND: [{ startTime: { lt: end } }, { endTime: { gt: start } }],
+        },
+      });
+
+      if (overlapCount > 0) throw new Error("Horário em conflito");
+
+      return await tx.appointment.update({
+        where: { id },
+        data: {
+          startTime: start,
+          endTime: end,
+          serviceId,
+          status: parsed.status,
+        },
+      });
+    });
+
+    return NextResponse.json<ApiResponse>({ success: true, data: updated });
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const errorDetails = err.issues.map((i) => ({
+        path: i.path.join("."),
+        message: i.message,
+      }));
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "Erro de validação", errorDetails },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: (err as Error).message || "Erro ao atualizar" },
+      { status: 500 }
+    );
+  }
+}
+
+// -------------------
+// DELETE - remover appointment
+// -------------------
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id } = params;
+    if (!id)
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "id é obrigatório" },
+        { status: 400 }
+      );
+
+    await prisma.appointment.delete({ where: { id } });
+    return NextResponse.json<ApiResponse>({ success: true, data: { id } });
+  } catch (err) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: (err as Error).message || "Erro ao deletar" },
       { status: 500 }
     );
   }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -37,6 +37,7 @@ export async function POST(req: Request) {
     value: token,
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
     path: "/",
     maxAge: 60 * 60 * 24,
   });

--- a/src/app/api/auth/whoami/route.ts
+++ b/src/app/api/auth/whoami/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { getUserFromCookie } from "@/app/libs/auth";
+
+export async function GET() {
+  const user = await getUserFromCookie();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  return NextResponse.json({ success: true, user });
+}

--- a/src/app/api/company/[id]/professionals/route.ts
+++ b/src/app/api/company/[id]/professionals/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const { id } = params;
+
+  if (!id) {
+    return NextResponse.json(
+      { success: false, error: "id é obrigatório" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const users = await prisma.user.findMany({
+      where: { companyId: id },
+      select: { id: true, name: true }, // só o necessário para o frontend
+    });
+
+    return NextResponse.json({ success: true, data: users });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: (err as Error).message || "Erro ao buscar profissionais",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/company/[id]/route.ts
+++ b/src/app/api/company/[id]/route.ts
@@ -1,9 +1,9 @@
 // app/api/company/[id]/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient, Company } from "@/generated/prisma";
+import { Company } from "@/generated/prisma";
 import { getUserFromCookie, JWTPayload } from "@/app/libs/auth";
 
-const prisma = new PrismaClient();
+import prisma from "@/lib/prisma";
 
 interface CompanyParams {
   id: string;

--- a/src/app/api/company/route.ts
+++ b/src/app/api/company/route.ts
@@ -1,10 +1,10 @@
 // app/api/company/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient, Company } from "@/generated/prisma";
+import { Company } from "@/generated/prisma";
 import { getUserFromCookie, JWTPayload } from "@/app/libs/auth";
 import { z, ZodError } from "zod";
 
-const prisma = new PrismaClient();
+import prisma from "@/lib/prisma";
 
 // Schema para validar dados da empresa
 const companySchema = z.object({

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
-import { PrismaClient } from "@/generated/prisma";
 import { NextResponse } from "next/server";
 
 import { verifyRecaptcha } from "../../libs/verifyRecaptcha";
 import { checkRateLimit } from "../../libs/rateLimit";
 
-const prisma = new PrismaClient();
+import prisma from "@/lib/prisma";
 
 const leadSchema = z.object({
   name: z.string().min(2),

--- a/src/app/api/professional-service/[id]/route.ts
+++ b/src/app/api/professional-service/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+
+// DELETE /api/professional-service/[id]
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id } = params;
+
+    await prisma.professionalService.delete({ where: { id } });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    const error = err as Error;
+    return NextResponse.json(
+      { success: false, error: error.message || "Erro ao deletar associação" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/professional-service/route.ts
+++ b/src/app/api/professional-service/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z, ZodError } from "zod";
+
+import prisma from "@/lib/prisma";
+
+// Validação de associação profissional-serviço
+const professionalServiceSchema = z.object({
+  professionalId: z.string().min(1, "O ID do profissional é obrigatório"),
+  serviceId: z.string().min(1, "O ID do serviço é obrigatório"),
+});
+
+// GET /api/professional-service?companyId=...&professionalId=...
+export async function GET(req: NextRequest) {
+  const companyId = req.nextUrl.searchParams.get("companyId");
+  const professionalId = req.nextUrl.searchParams.get("professionalId");
+
+  if (!companyId && !professionalId) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "É necessário informar companyId ou professionalId",
+      },
+      { status: 400 }
+    );
+  }
+
+  let associations;
+
+  if (professionalId) {
+    // Buscar apenas os serviços de um profissional
+    associations = await prisma.professionalService.findMany({
+      where: { professionalId },
+      include: {
+        service: true,
+        professional: true,
+      },
+    });
+  } else if (companyId) {
+    // Buscar todos os professionalServices de uma empresa
+    associations = await prisma.professionalService.findMany({
+      where: {
+        service: {
+          companyId,
+        },
+      },
+      include: {
+        service: true,
+        professional: true,
+      },
+    });
+  }
+
+  return NextResponse.json({ success: true, data: associations });
+}
+
+// POST /api/professional-service
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const parsed = professionalServiceSchema.parse(body);
+
+    const created = await prisma.professionalService.create({ data: parsed });
+
+    return NextResponse.json({ success: true, data: created });
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const errorDetails = err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message,
+      }));
+      return NextResponse.json(
+        { success: false, error: "Erro de validação", errorDetails },
+        { status: 400 }
+      );
+    }
+
+    const error = err as Error;
+    return NextResponse.json(
+      { success: false, error: error.message || "Erro ao criar associação" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/services/[id]/route.ts
+++ b/src/app/api/services/[id]/route.ts
@@ -1,0 +1,94 @@
+// api/services/[id]/route.ts
+
+import { NextRequest, NextResponse } from "next/server";
+import { Service } from "@/generated/prisma";
+import { z, ZodError } from "zod";
+
+import prisma from "@/lib/prisma";
+
+interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorDetails?: { path: string; message: string }[];
+}
+
+// Validação de Service
+const serviceSchema = z.object({
+  companyId: z.string(),
+  name: z.string().min(1, "O nome do serviço é obrigatório"),
+  price: z
+    .number({ invalid_type_error: "O preço deve ser um número" })
+    .nonnegative("O preço não pode ser negativo"),
+  duration: z
+    .number({ invalid_type_error: "A duração deve ser um número" })
+    .positive("A duração deve ser maior que 0"),
+});
+
+type ServiceInput = z.infer<typeof serviceSchema>;
+
+// PUT /api/services/:id
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body: unknown = await req.json();
+    const parsed: Partial<ServiceInput> = serviceSchema.partial().parse(body);
+
+    const updated: Service = await prisma.service.update({
+      where: { id: params.id },
+      data: parsed,
+    });
+
+    return NextResponse.json<ApiResponse<Service>>({
+      success: true,
+      data: updated,
+    });
+  } catch (err: unknown) {
+    if (err instanceof ZodError) {
+      return NextResponse.json<ApiResponse>(
+        {
+          success: false,
+          error: "Erro de validação",
+          errorDetails: err.issues.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        },
+        { status: 400 }
+      );
+    }
+
+    const error =
+      err instanceof Error ? err.message : "Erro ao atualizar serviço";
+    return NextResponse.json<ApiResponse>(
+      { success: false, error },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE /api/services/:id
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const deleted: Service = await prisma.service.delete({
+      where: { id: params.id },
+    });
+
+    return NextResponse.json<ApiResponse<Service>>({
+      success: true,
+      data: deleted,
+    });
+  } catch (err: unknown) {
+    const error =
+      err instanceof Error ? err.message : "Erro ao deletar serviço";
+    return NextResponse.json<ApiResponse>(
+      { success: false, error },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/services/route.ts
+++ b/src/app/api/services/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Service } from "@/generated/prisma";
+import { z, ZodError } from "zod";
+
+import prisma from "@/lib/prisma";
+
+interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorDetails?: { path: string; message: string }[];
+}
+
+// Validação de Service
+const serviceSchema = z.object({
+  companyId: z.string(),
+  name: z.string().min(1, "O nome do serviço é obrigatório"),
+  price: z
+    .number({ invalid_type_error: "O preço deve ser um número" })
+    .nonnegative("O preço não pode ser negativo"),
+  duration: z
+    .number({ invalid_type_error: "A duração deve ser um número" })
+    .positive("A duração deve ser maior que 0"), // em minutos
+});
+
+type ServiceInput = z.infer<typeof serviceSchema>;
+
+// GET /api/services?companyId=...
+export async function GET(req: NextRequest) {
+  const companyId = req.nextUrl.searchParams.get("companyId");
+  if (!companyId) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "companyId é obrigatório" },
+      { status: 400 }
+    );
+  }
+  console.log("companyId:", companyId);
+  try {
+    const services: Service[] = await prisma.service.findMany({
+      where: { companyId },
+      orderBy: { name: "asc" },
+    });
+
+    return NextResponse.json<ApiResponse<Service[]>>({
+      success: true,
+      data: services,
+    });
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : "Erro desconhecido";
+    return NextResponse.json<ApiResponse>(
+      { success: false, error },
+      { status: 500 }
+    );
+  }
+}
+
+// POST /api/services
+export async function POST(req: NextRequest) {
+  try {
+    const body: unknown = await req.json();
+    const parsed: ServiceInput = serviceSchema.parse(body);
+
+    const created: Service = await prisma.service.create({ data: parsed });
+    return NextResponse.json<ApiResponse<Service>>({
+      success: true,
+      data: created,
+    });
+  } catch (err: unknown) {
+    if (err instanceof ZodError) {
+      const errorDetails = err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message,
+      }));
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "Erro de validação", errorDetails },
+        { status: 400 }
+      );
+    }
+
+    const error = err instanceof Error ? err.message : "Erro ao salvar serviço";
+    return NextResponse.json<ApiResponse>(
+      { success: false, error },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/working-hours/[id]/route.ts
+++ b/src/app/api/working-hours/[id]/route.ts
@@ -1,0 +1,106 @@
+// app/api/working-hours/[id]/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { WorkingHours } from "@/generated/prisma";
+import { z, ZodError } from "zod";
+import prisma from "@/lib/prisma";
+
+// Tipagem de retorno padrão
+interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorDetails?: { path?: string; message: string }[];
+}
+
+// Schema para validação de atualização (parcial)
+const workingHoursUpdateSchema = z.object({
+  dayOfWeek: z.number().min(0).max(6).optional(),
+  openTime: z
+    .string()
+    .regex(/^([0-1]\d|2[0-3]):([0-5]\d)$/)
+    .optional(),
+  closeTime: z
+    .string()
+    .regex(/^([0-1]\d|2[0-3]):([0-5]\d)$/)
+    .optional(),
+});
+
+type WorkingHoursUpdateInput = z.infer<typeof workingHoursUpdateSchema>;
+
+// PUT /api/working-hours/[id]
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body: unknown = await req.json();
+    const parsed: WorkingHoursUpdateInput =
+      workingHoursUpdateSchema.parse(body);
+
+    if (
+      parsed.openTime &&
+      parsed.closeTime &&
+      parsed.openTime >= parsed.closeTime
+    ) {
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "openTime deve ser menor que closeTime" },
+        { status: 400 }
+      );
+    }
+
+    const updated: WorkingHours = await prisma.workingHours.update({
+      where: { id: params.id },
+      data: parsed,
+    });
+
+    return NextResponse.json<ApiResponse<WorkingHours>>({
+      success: true,
+      data: updated,
+    });
+  } catch (err: unknown) {
+    if (err instanceof ZodError) {
+      return NextResponse.json<ApiResponse>(
+        {
+          success: false,
+          error: "Erro de validação",
+          errorDetails: err.issues.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        },
+        { status: 400 }
+      );
+    }
+
+    const error = err instanceof Error ? err.message : "Erro desconhecido";
+
+    return NextResponse.json<ApiResponse>(
+      { success: false, error },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE /api/working-hours/[id]
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const deleted: WorkingHours = await prisma.workingHours.delete({
+      where: { id: params.id },
+    });
+
+    return NextResponse.json<ApiResponse<WorkingHours>>({
+      success: true,
+      data: deleted,
+    });
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : "Erro desconhecido";
+
+    return NextResponse.json<ApiResponse>(
+      { success: false, error },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/working-hours/route.ts
+++ b/src/app/api/working-hours/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { WorkingHours } from "@/generated/prisma";
+import { z, ZodError } from "zod";
+
+import prisma from "@/lib/prisma";
+
+// Tipagem de retorno padrão
+interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  errorDetails?: { path?: string; message: string }[];
+}
+
+// Validação de WorkingHours
+const workingHoursSchema = z.object({
+  companyId: z.string(),
+  dayOfWeek: z.number().min(0).max(6),
+  openTime: z.string().regex(/^([0-1]\d|2[0-3]):([0-5]\d)$/), // HH:mm
+  closeTime: z.string().regex(/^([0-1]\d|2[0-3]):([0-5]\d)$/), // HH:mm
+});
+
+type WorkingHoursInput = z.infer<typeof workingHoursSchema>;
+
+// GET /api/working-hours?companyId=...
+export async function GET(req: NextRequest) {
+  const companyId = req.nextUrl.searchParams.get("companyId");
+  if (!companyId) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "companyId é obrigatório" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const hours: WorkingHours[] = await prisma.workingHours.findMany({
+      where: { companyId },
+      orderBy: { dayOfWeek: "asc" },
+    });
+
+    return NextResponse.json<ApiResponse<WorkingHours[]>>({
+      success: true,
+      data: hours,
+    });
+  } catch (err: unknown) {
+    const error = err instanceof Error ? err.message : "Erro desconhecido";
+    return NextResponse.json<ApiResponse>(
+      {
+        success: false,
+        error,
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// POST /api/working-hours
+export async function POST(req: NextRequest) {
+  try {
+    const body: unknown = await req.json();
+    const parsed: WorkingHoursInput = workingHoursSchema.parse(body);
+
+    if (parsed.openTime >= parsed.closeTime) {
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "openTime deve ser menor que closeTime" },
+        { status: 400 }
+      );
+    }
+
+    const created: WorkingHours = await prisma.workingHours.create({
+      data: parsed,
+    });
+
+    return NextResponse.json<ApiResponse<WorkingHours>>({
+      success: true,
+      data: created,
+    });
+  } catch (err: unknown) {
+    if (err instanceof ZodError) {
+      const errorDetails = err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message,
+      }));
+
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "Erro de validação", errorDetails },
+        { status: 400 }
+      );
+    }
+
+    const error = err instanceof Error ? err.message : "Erro desconhecido";
+
+    return NextResponse.json<ApiResponse>(
+      { success: false, error },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client"; // se estiver usando App Router (Next 13+)
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 // import Image from "next/image";
 import { Menu, X } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -10,6 +10,7 @@ import Button from "./ui/Button";
 
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
+  const [user, setUser] = useState<{ id: string; name: string } | null>(null);
 
   const navItems = [
     { label: "Como funciona", href: "/#how" },
@@ -17,6 +18,33 @@ export default function Header() {
     { label: "Dúvidas", href: "/#faq" },
     { label: "Entrar", href: "/leads" },
   ];
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await fetch("/api/auth/whoami");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (mounted && data?.user) setUser({ id: data.user.id, name: data.user.name });
+      } catch (e) {
+        // ignore
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  async function handleLogout() {
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+      window.location.href = "/";
+    } catch (e) {
+      window.location.href = "/";
+    }
+  }
 
   return (
     <AnimatePresence>
@@ -48,6 +76,14 @@ export default function Header() {
             <Button asLink href="/leads" size="sm">
               Comece grátis
             </Button>
+            {user ? (
+              <div className="flex items-center gap-4">
+                <span className="text-sm">Olá, {user.name}</span>
+                <button className="text-sm text-red-500" onClick={handleLogout}>
+                  Sair
+                </button>
+              </div>
+            ) : null}
           </nav>
 
           {/* Botão Mobile */}

--- a/src/app/components/ui/Button.tsx
+++ b/src/app/components/ui/Button.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { ButtonHTMLAttributes, AnchorHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, AnchorHTMLAttributes, ReactNode } from "react";
 
-// Tipos possíveis de botão ou link
 type CommonProps = {
-  variant?: "primary" | "secondary" | "outlined";
+  variant?: "primary" | "secondary" | "outlined" | "destructive";
   asLink?: boolean;
   mt?: "none" | "xs" | "sm" | "md" | "lg" | "xlg";
   size?: "xs" | "sm" | "md" | "lg" | "xlg";
   w?: "auto" | "full";
+  loading?: boolean;
+  children: ReactNode;
 };
 
-// União de tipos com base na tag
 type ButtonProps =
   | (CommonProps & ButtonHTMLAttributes<HTMLButtonElement>)
   | (CommonProps & AnchorHTMLAttributes<HTMLAnchorElement>);
@@ -23,15 +23,17 @@ export default function Button({
   mt = "none",
   size = "md",
   w = "auto",
+  loading = false,
   ...props
 }: ButtonProps) {
   const baseClass =
-    "rounded font-semibold hover:scale-105 cursor-pointer transition";
+    "rounded font-semibold hover:scale-105 cursor-pointer transition flex items-center justify-center gap-2";
 
   const variants = {
     primary: "bg-primary text-white hover:bg-primary-hover",
     secondary: "text-primary",
     outlined: "text-primary border hover:bg-secondary-hover",
+    destructive: "bg-red-500 text-white hover:bg-red-600",
   };
 
   const marginTopMap = {
@@ -56,32 +58,56 @@ export default function Button({
     full: "w-full",
   };
 
-  const className = `${baseClass} ${variants[variant]} ${marginTopMap[mt]} ${sizeMap[size]} ${widthMap[w]}`;
+  const className = `${baseClass} ${variants[variant]} ${marginTopMap[mt]} ${
+    sizeMap[size]
+  } ${widthMap[w]} ${loading ? "opacity-70 cursor-not-allowed" : ""}`;
+
+  const Spinner = () => (
+    <svg
+      className="animate-spin h-5 w-5 text-white"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      ></path>
+    </svg>
+  );
+
+  const content = loading ? <Spinner /> : children;
 
   if (asLink) {
     return (
-      <div className="flex flex-col sm:flex-row justify-center">
-        <a
-          className={className}
-          {...(props as AnchorHTMLAttributes<HTMLAnchorElement>)}
-        >
-          {children}
-        </a>
-      </div>
+      <a
+        className={className}
+        {...(props as AnchorHTMLAttributes<HTMLAnchorElement>)}
+      >
+        {content}
+      </a>
     );
   }
 
   return (
-    <div className="flex flex-col sm:flex-row justify-center">
-      <button
-        className={className}
-        type={
-          (props as ButtonHTMLAttributes<HTMLButtonElement>).type || "button"
-        }
-        {...(props as ButtonHTMLAttributes<HTMLButtonElement>)}
-      >
-        {children}
-      </button>
-    </div>
+    <button
+      className={className}
+      type={(props as ButtonHTMLAttributes<HTMLButtonElement>).type || "button"}
+      disabled={
+        loading || (props as ButtonHTMLAttributes<HTMLButtonElement>).disabled
+      }
+      {...(props as ButtonHTMLAttributes<HTMLButtonElement>)}
+    >
+      {content}
+    </button>
   );
 }

--- a/src/app/components/ui/Select.tsx
+++ b/src/app/components/ui/Select.tsx
@@ -14,7 +14,11 @@ type SelectProps = CommonProps & {
   options: { label: string; value: string }[];
   placeholder?: string;
   defaultValue?: string;
+  value?: string;
+  // onValueChange is kept for existing usage; onChange is an alias used across the codebase
   onValueChange?: (value: string) => void;
+  onChange?: (value: string) => void;
+  disabled?: boolean;
 };
 
 export default function Select({
@@ -26,6 +30,9 @@ export default function Select({
   w = "auto",
   defaultValue,
   onValueChange,
+  value,
+  onChange,
+  disabled,
 }: SelectProps) {
   const baseClass =
     "flex items-center justify-between rounded font-medium transition cursor-pointer";
@@ -63,9 +70,10 @@ export default function Select({
   return (
     <SelectPrimitive.Root
       defaultValue={defaultValue}
-      onValueChange={onValueChange}
+      value={value}
+      onValueChange={onValueChange ?? onChange}
     >
-      <SelectPrimitive.Trigger className={className}>
+      <SelectPrimitive.Trigger className={className} disabled={disabled}>
         <SelectPrimitive.Value placeholder={placeholder} />
         <SelectPrimitive.Icon>
           <ChevronDown className="w-4 h-4" />

--- a/src/app/components/ui/ToastErrorProvider.tsx
+++ b/src/app/components/ui/ToastErrorProvider.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { createContext, useContext, useState } from "react";
+import * as Toast from "@radix-ui/react-toast";
+
+type ToastType = "success" | "error" | "info";
+
+interface ToastMessage {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+type ToastContextType = (message: string, type?: ToastType) => void;
+
+const ToastContext = createContext<ToastContextType>(() => {});
+
+export const useToast = () => useContext(ToastContext);
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [queue, setQueue] = useState<ToastMessage[]>([]);
+
+  const showToast = (message: string, type: ToastType = "info") => {
+    setQueue((prev) => [...prev, { id: Date.now(), message, type }]);
+  };
+
+  return (
+    <Toast.Provider swipeDirection="right">
+      <ToastContext.Provider value={showToast}>
+        {children}
+
+        {queue.map((toast) => (
+          <ToastItem
+            key={toast.id}
+            message={toast.message}
+            type={toast.type}
+            onClose={() =>
+              setQueue((prev) => prev.filter((t) => t.id !== toast.id))
+            }
+          />
+        ))}
+
+        {/* Viewport Radix */}
+        <Toast.Viewport className="fixed bottom-4 right-4 flex flex-col gap-2 z-50 w-[280px] max-w-[90vw] outline-none" />
+      </ToastContext.Provider>
+    </Toast.Provider>
+  );
+};
+
+interface ToastItemProps {
+  message: string;
+  type: ToastType;
+  onClose: () => void;
+}
+
+const ToastItem: React.FC<ToastItemProps> = ({ message, type, onClose }) => {
+  const [open, setOpen] = useState(true);
+
+  const typeStyles: Record<ToastType, string> = {
+    success: "bg-green-600",
+    error: "bg-red-600",
+    info: "bg-blue-600",
+  };
+
+  return (
+    <Toast.Root
+      open={open}
+      duration={3000}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) onClose();
+      }}
+      className={`${typeStyles[type]} text-white rounded-md p-2 shadow-lg animate-slide-in-right`}
+    >
+      <Toast.Title className="font-bold capitalize">{type}</Toast.Title>
+      <Toast.Description className="whitespace-pre-wrap">
+        {message}
+      </Toast.Description>
+      <Toast.Action
+        className="text-white underline ml-2"
+        altText="Fechar"
+        onClick={() => setOpen(false)}
+      >
+        Fechar
+      </Toast.Action>
+    </Toast.Root>
+  );
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,3 +59,38 @@ h3,
 .titulo {
   font-family: "Poppins", sans-serif;
 }
+
+/* gap entre os dias do mês */
+.react-calendar__month-view__days,
+.react-calendar__month-view__weekdays {
+  display: grid !important;
+  grid-template-columns: repeat(7, 1fr) !important;
+  gap: 4px;
+}
+
+.react-calendar__month-view__weekdays__weekday {
+  color: #555555 !important;
+  font-weight: 900 !important;
+}
+
+.react-calendar__month-view__weekdays__weekday abbr {
+  text-decoration: none !important;
+}
+
+.react-calendar__navigation__prev-button,
+.react-calendar__navigation__next-button,
+.react-calendar__navigation__label {
+  border-radius: 0.375rem !important;
+  background: transparent !important;
+}
+
+.react-calendar__navigation__prev-button:hover,
+.react-calendar__navigation__next-button:hover,
+.react-calendar__navigation__label:hover {
+  background: #f0f0f0 !important;
+}
+
+.react-calendar__navigation__label__labelText {
+  font-weight: 900 !important;
+  color: #555555 !important;
+}

--- a/src/hooks/useErrorModal.ts
+++ b/src/hooks/useErrorModal.ts
@@ -1,0 +1,11 @@
+// hooks/useErrorModal.ts
+"use client";
+import { useState } from "react";
+
+export default function useErrorModal() {
+  const [error, setError] = useState<string | null>(null);
+  const showError = (msg: string) => setError(msg);
+  const close = () => setError(null);
+
+  return { error, showError, close };
+}

--- a/src/lib/__tests__/appointments.test.ts
+++ b/src/lib/__tests__/appointments.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { prismaToUI, uiToPrisma } from '@/lib/appointments';
+import { Appointment as PrismaAppointment, AppointmentStatus } from '@/generated/prisma';
+
+describe('appointments helper', () => {
+  it('prismaToUI converts prisma appointment to UIAppointment', () => {
+    const prisma: PrismaAppointment = {
+      id: '1',
+      companyId: 'cmp-1',
+      professionalId: 'prof-1',
+      clientName: 'João',
+      serviceId: 'svc-1',
+      price: 50,
+      startTime: new Date('2025-09-30T10:00:00.000Z'),
+      endTime: new Date('2025-09-30T11:00:00.000Z'),
+      status: AppointmentStatus.PENDING,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as PrismaAppointment;
+
+    const ui = prismaToUI(prisma);
+    expect(ui).not.toBeNull();
+    expect(ui?.id).toBe('1');
+    expect(ui?.clientName).toBe('João');
+    expect(ui?.service).toBe('svc-1');
+    expect(ui?.price).toBe(50);
+    expect(ui?.date.startsWith('2025-09-30')).toBe(true);
+  });
+
+  it('uiToPrisma converts UI form to prisma payload', () => {
+    const form: Record<string, unknown> = {
+      clientName: 'Maria',
+      service: 'svc-2',
+      price: 80,
+      date: '2025-10-01T09:00',
+    };
+
+    const payload = uiToPrisma(form);
+    expect(payload.clientName).toBe('Maria');
+    expect(payload.serviceId).toBe('svc-2');
+    expect(typeof payload.startTime).toBe('string');
+  });
+});

--- a/src/lib/appointments.ts
+++ b/src/lib/appointments.ts
@@ -1,0 +1,56 @@
+import { Appointment as PrismaAppointment } from "@/generated/prisma";
+
+export interface UIAppointment {
+  id: string;
+  clientName: string;
+  service: string; // service name (if relation expanded) or serviceId fallback
+  serviceId?: string; // original serviceId from Prisma
+  price: number;
+  date: string; // ISO-like yyyy-mm-ddTHH:MM
+  status: PrismaAppointment["status"];
+}
+
+/**
+ * Converte um objeto Appointment do Prisma para o formato usado pela UI.
+ * Faz parsing seguro de campos opcionais (price, serviceId/startTime etc.).
+ */
+export function prismaToUI(appt: PrismaAppointment | null | undefined): UIAppointment | null {
+  if (!appt) return null;
+
+  const start = appt.startTime ? new Date(appt.startTime) : new Date();
+  // prefer relational `service` string if populated, otherwise fallback to serviceId
+  const hasServiceProp = (o: unknown): o is { service?: unknown } => {
+    return !!o && typeof o === "object" && "service" in (o as Record<string, unknown>);
+  };
+
+  const apptRecord = appt as Record<string, unknown>;
+  const service = hasServiceProp(appt) && typeof apptRecord.service === "string"
+    ? (apptRecord.service as string)
+    : appt.serviceId ?? "";
+  return {
+    id: appt.id,
+    clientName: appt.clientName ?? "",
+    service: String(service),
+    serviceId: appt.serviceId,
+    price: appt.price ?? 0,
+    date: start.toISOString().slice(0, 16),
+    status: appt.status,
+  };
+}
+
+/**
+ * Converte o formato UI para o payload esperado pela API/Prisma.
+ * Recebe um UIAppointment parcial (form) e converte date (string) para ISO.
+ */
+export function uiToPrisma(form: Partial<UIAppointment> & { serviceId?: string }) {
+  const startTime = form.date ? new Date(form.date).toISOString() : undefined;
+  return {
+    clientName: form.clientName,
+    // support legacy `service` field from UI forms (fallback) and prefer explicit serviceId
+    serviceId: form.serviceId ?? (form as Record<string, unknown>).service ?? undefined,
+    price: form.price,
+    startTime,
+  };
+}
+
+export default prismaToUI;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,1 @@
+export { getUserFromCookie as getCurrentUser } from "@/app/libs/auth";

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,14 @@
+// src/lib/prisma.ts
+import { PrismaClient } from "@/generated/prisma";
+
+declare global {
+  // Isso diz pro TypeScript que globalThis pode ter um prisma
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+const prisma = globalThis.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV === "development") globalThis.prisma = prisma;
+
+export default prisma;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getUserFromCookie } from "./libs/auth";
+import { getUserFromCookie } from "./app/libs/auth";
 
 export function middleware(req: NextRequest) {
   // Protege qualquer rota que comece com /dashboard ou /app/protected

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
### Resumo

Centraliza e padroniza a conversão entre o model Prisma Appointment e o formato usado pela UI.
Evita casts inseguros (as any, as unknown) e reduz inconsistências entre backend e frontend.

### O que foi feito

- Criado helper de normalização: appointments.ts
- Exporta prismaToUI, uiToPrisma e o tipo UIAppointment.
- UIAppointment contém: 
- date (ISO até minutos)
- service (nome/label)
- serviceId (opcional)
- UI atualizada para consumir o formato normalizado:
- AppointmentForm.tsx
- page.tsx
- AppointmentList.tsx (já utilizava UIAppointment)

### Testes:

- appointments.test.ts — unitários para prismaToUI e uiToPrisma
- vitest.config.ts adicionado para resolver alias @

**Configurações:**

- tsconfig.json — removida inclusão de types para evitar conflitos de geração local
- Branch / Commit### 
- Branch: feature/normalize-appointments
- Commit principal: "Normalize UI appointments via prismaToUI; fix types & tests"

### Por que isso importa

- Centralizar a conversão reduz duplicação e bugs por divergência de nomes (startTime vs date).
- Facilita manutenção e futuras mudanças no backend sem espalhar casts pela UI.

### Como testar localmente

1. Instalar dependências (se necessário)
2. Rodar checagem TypeScript (npx tsc --noEmit)
3. Executar testes unitários (Vitest)
4. Subir aplicação em dev
5. Fazer smoke test manual: criar / editar / cancelar um agendamento na UI

### Arquivos-chave para revisar

- appointments.ts (helper + tipos)
- page.tsx
- AppointmentForm.tsx
- appointments.test.ts
- tsconfig.json

### Checklist pro PR

- [ ]  TypeScript check local (npx tsc --noEmit)
- [ ]  Unit tests (Vitest) passando
- [ ]  Manual smoke test: criar/editar/cancelar agendamento
- [ ]  Revisão de UX/format de data por QA (opcional)

### Notas e observações

- Rotas do backend (src/app/api/**) continuam usando startTime/serviceId — intencional; normalização acontece apenas na UI.
- UIAppointment.date usa ISO truncado até minutos (ex.: 2025-09-29T10:00).
- Se quisermos consistência timezone-aware, sugerido padronizar UTC ou usar libs (date-fns / Intl) + testes E2E.
- .env.example atualizado para lembrar sobre JWT_SECRET e reCAPTCHA.

### Sugestões

Labels: refactor, tests, type:cleanup