### PR TITLE
Fix Next build type generation errors by making API route handlers robust

### DIFF
--- a/src/app/(app)/dashboard/appointments/AppointmentForm.tsx
+++ b/src/app/(app)/dashboard/appointments/AppointmentForm.tsx
@@ -6,8 +6,13 @@ import "react-calendar/dist/Calendar.css";
 import Button from "@/app/components/ui/Button";
 import Input from "@/app/components/ui/Input";
 import { z } from "zod";
-import { AppointmentStatus, Appointment as PrismaAppointment } from "@/generated/prisma";
-import prismaToUI, { UIAppointment as HelperUIAppointment } from "@/lib/appointments";
+import {
+  AppointmentStatus,
+  Appointment as PrismaAppointment,
+} from "@/generated/prisma";
+import prismaToUI, {
+  UIAppointment as HelperUIAppointment,
+} from "@/lib/appointments";
 
 import {
   Chart as ChartJS,
@@ -73,10 +78,16 @@ export default function AppointmentForm({ appointment, onClose }: Props) {
 
     // runtime type guard: detect Prisma shape (has startTime)
     const isPrisma = (a: unknown): a is PrismaAppointment => {
-      return !!a && typeof a === "object" && "startTime" in (a as Record<string, unknown>);
+      return (
+        !!a &&
+        typeof a === "object" &&
+        "startTime" in (a as Record<string, unknown>)
+      );
     };
 
-    const ui = isPrisma(appointment) ? prismaToUI(appointment) ?? appointment : appointment;
+    const ui = isPrisma(appointment)
+      ? prismaToUI(appointment) ?? appointment
+      : appointment;
 
     const safeDate = ui.date ? new Date(ui.date) : new Date();
 
@@ -101,7 +112,7 @@ export default function AppointmentForm({ appointment, onClose }: Props) {
       const from = selectedDate.toISOString().split("T")[0];
       const to = from;
       const res = await fetch(`/api/appointments?from=${from}&to=${to}`);
-  const data: UIAppointment[] = await res.json();
+      const data: UIAppointment[] = await res.json();
 
       const slots: AvailableSlot[] = Array.from({ length: 10 }, (_, i) => {
         const hour = 9 + i;
@@ -263,7 +274,8 @@ export default function AppointmentForm({ appointment, onClose }: Props) {
               // react-calendar's onChange can be Date or Date[] (range). Normalize safely.
               onChange={(value: Date | Date[] | unknown) => {
                 if (value instanceof Date) setSelectedDate(value);
-                else if (Array.isArray(value) && value[0] instanceof Date) setSelectedDate(value[0]);
+                else if (Array.isArray(value) && value[0] instanceof Date)
+                  setSelectedDate(value[0]);
               }}
               value={selectedDate}
               className="rounded-lg shadow-sm"

--- a/src/app/(app)/dashboard/appointments/page.tsx
+++ b/src/app/(app)/dashboard/appointments/page.tsx
@@ -36,9 +36,11 @@ export default function AppointmentsPage() {
     const res = await fetch(
       `/api/appointments${query.length ? `?${query.join("&")}` : ""}`
     );
-  const data: Appointment[] = await res.json();
-  const ui = data.map((d) => prismaToUI(d)!).filter(Boolean) as UIAppointment[];
-  setAppointments(ui);
+    const data: Appointment[] = await res.json();
+    const ui = data
+      .map((d) => prismaToUI(d)!)
+      .filter(Boolean) as UIAppointment[];
+    setAppointments(ui);
   }, [filters]);
 
   useEffect(() => {

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -297,12 +297,24 @@ export async function PUT(req: NextRequest) {
 // DELETE - remover appointment
 // -------------------
 
-export async function DELETE(
-  req: NextRequest,
-  { params }: { params: { id: string } }
-) {
+export async function DELETE(req: NextRequest) {
   try {
-    const { id } = params;
+    // This route is mounted at /api/appointments (not a dynamic [id] route),
+    // so Next's generated RouteContext won't include params here. Read the id
+    // from the query string or, as a fallback, from the JSON body.
+    const searchId = req.nextUrl.searchParams.get("id");
+    let id: string | null = searchId;
+
+    if (!id) {
+      try {
+        const body = await req.json();
+        id = body?.id ?? null;
+      } catch {
+        // ignore JSON parse errors
+        id = null;
+      }
+    }
+
     if (!id)
       return NextResponse.json<ApiResponse>(
         { success: false, error: "id é obrigatório" },

--- a/src/app/api/auth/whoami/route.ts
+++ b/src/app/api/auth/whoami/route.ts
@@ -3,7 +3,8 @@ import { getUserFromCookie } from "@/app/libs/auth";
 
 export async function GET() {
   const user = await getUserFromCookie();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   return NextResponse.json({ success: true, user });
 }

--- a/src/app/api/company/[id]/professionals/route.ts
+++ b/src/app/api/company/[id]/professionals/route.ts
@@ -2,11 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 
 import prisma from "@/lib/prisma";
 
-export async function GET(
-  req: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  const { id } = params;
+export async function GET(req: NextRequest) {
+  // This route is defined under /api/company/[id]/professionals but Next's
+  // generated RouteContext can be strict about handler signatures. To be
+  // resilient, read the id from the URL path (last segment) or the query
+  // string. If neither exists, return a 400.
+  const pathSegments = req.nextUrl.pathname.split("/").filter(Boolean);
+  const lastSegment = pathSegments[pathSegments.length - 2];
+  // in case the path is /api/company/{id}/professionals
+  const idFromPath = lastSegment;
+  const idFromQuery = req.nextUrl.searchParams.get("id");
+  const id = idFromQuery ?? idFromPath;
 
   if (!id) {
     return NextResponse.json(

--- a/src/app/api/professional-service/[id]/route.ts
+++ b/src/app/api/professional-service/[id]/route.ts
@@ -3,12 +3,19 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 
 // DELETE /api/professional-service/[id]
-export async function DELETE(
-  req: NextRequest,
-  { params }: { params: { id: string } }
-) {
+export async function DELETE(req: NextRequest) {
   try {
-    const { id } = params;
+    const pathSegments = req.nextUrl.pathname.split("/").filter(Boolean);
+    const idFromPath = pathSegments[pathSegments.length - 1];
+    const idFromQuery = req.nextUrl.searchParams.get("id");
+    const id = idFromQuery ?? idFromPath;
+
+    if (!id) {
+      return NextResponse.json(
+        { success: false, error: "id é obrigatório" },
+        { status: 400 }
+      );
+    }
 
     await prisma.professionalService.delete({ where: { id } });
 

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -14,15 +14,23 @@ export async function POST(req: Request) {
   };
 
   // Rate limit by IP (best-effort using x-forwarded-for header)
-  const ip = req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || "unknown";
+  const ip =
+    req.headers.get("x-forwarded-for") ||
+    req.headers.get("x-real-ip") ||
+    "unknown";
   const allowed = await checkRateLimit(ip);
   if (!allowed)
-    return new Response(JSON.stringify({ message: "Too many requests" }), { status: 429 });
+    return new Response(JSON.stringify({ message: "Too many requests" }), {
+      status: 429,
+    });
 
   // If recaptcha is configured, verify token
   if (recaptchaToken) {
     const ok = await verifyRecaptcha(recaptchaToken);
-    if (!ok) return new Response(JSON.stringify({ message: "reCAPTCHA failed" }), { status: 400 });
+    if (!ok)
+      return new Response(JSON.stringify({ message: "reCAPTCHA failed" }), {
+        status: 400,
+      });
   }
 
   const exists = await prisma.user.findUnique({ where: { email } });

--- a/src/app/api/services/[id]/route.ts
+++ b/src/app/api/services/[id]/route.ts
@@ -28,16 +28,25 @@ const serviceSchema = z.object({
 type ServiceInput = z.infer<typeof serviceSchema>;
 
 // PUT /api/services/:id
-export async function PUT(
-  req: NextRequest,
-  { params }: { params: { id: string } }
-) {
+export async function PUT(req: NextRequest) {
   try {
+    const pathSegments = req.nextUrl.pathname.split("/").filter(Boolean);
+    const idFromPath = pathSegments[pathSegments.length - 1];
+    const idFromQuery = req.nextUrl.searchParams.get("id");
+    const id = idFromQuery ?? idFromPath;
+
+    if (!id) {
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "id é obrigatório" },
+        { status: 400 }
+      );
+    }
+
     const body: unknown = await req.json();
     const parsed: Partial<ServiceInput> = serviceSchema.partial().parse(body);
 
     const updated: Service = await prisma.service.update({
-      where: { id: params.id },
+      where: { id },
       data: parsed,
     });
 
@@ -70,13 +79,22 @@ export async function PUT(
 }
 
 // DELETE /api/services/:id
-export async function DELETE(
-  req: NextRequest,
-  { params }: { params: { id: string } }
-) {
+export async function DELETE(req: NextRequest) {
   try {
+    const pathSegments = req.nextUrl.pathname.split("/").filter(Boolean);
+    const idFromPath = pathSegments[pathSegments.length - 1];
+    const idFromQuery = req.nextUrl.searchParams.get("id");
+    const id = idFromQuery ?? idFromPath;
+
+    if (!id) {
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "id é obrigatório" },
+        { status: 400 }
+      );
+    }
+
     const deleted: Service = await prisma.service.delete({
-      where: { id: params.id },
+      where: { id },
     });
 
     return NextResponse.json<ApiResponse<Service>>({

--- a/src/app/api/working-hours/[id]/route.ts
+++ b/src/app/api/working-hours/[id]/route.ts
@@ -28,11 +28,20 @@ const workingHoursUpdateSchema = z.object({
 type WorkingHoursUpdateInput = z.infer<typeof workingHoursUpdateSchema>;
 
 // PUT /api/working-hours/[id]
-export async function PUT(
-  req: NextRequest,
-  { params }: { params: { id: string } }
-) {
+export async function PUT(req: NextRequest) {
   try {
+    const pathSegments = req.nextUrl.pathname.split("/").filter(Boolean);
+    const idFromPath = pathSegments[pathSegments.length - 1];
+    const idFromQuery = req.nextUrl.searchParams.get("id");
+    const id = idFromQuery ?? idFromPath;
+
+    if (!id) {
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "id é obrigatório" },
+        { status: 400 }
+      );
+    }
+
     const body: unknown = await req.json();
     const parsed: WorkingHoursUpdateInput =
       workingHoursUpdateSchema.parse(body);
@@ -49,7 +58,7 @@ export async function PUT(
     }
 
     const updated: WorkingHours = await prisma.workingHours.update({
-      where: { id: params.id },
+      where: { id },
       data: parsed,
     });
 
@@ -82,13 +91,22 @@ export async function PUT(
 }
 
 // DELETE /api/working-hours/[id]
-export async function DELETE(
-  req: NextRequest,
-  { params }: { params: { id: string } }
-) {
+export async function DELETE(req: NextRequest) {
   try {
+    const pathSegments = req.nextUrl.pathname.split("/").filter(Boolean);
+    const idFromPath = pathSegments[pathSegments.length - 1];
+    const idFromQuery = req.nextUrl.searchParams.get("id");
+    const id = idFromQuery ?? idFromPath;
+
+    if (!id) {
+      return NextResponse.json<ApiResponse>(
+        { success: false, error: "id é obrigatório" },
+        { status: 400 }
+      );
+    }
+
     const deleted: WorkingHours = await prisma.workingHours.delete({
-      where: { id: params.id },
+      where: { id },
     });
 
     return NextResponse.json<ApiResponse<WorkingHours>>({

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -26,7 +26,8 @@ export default function Header() {
         const res = await fetch("/api/auth/whoami");
         if (!res.ok) return;
         const data = await res.json();
-        if (mounted && data?.user) setUser({ id: data.user.id, name: data.user.name });
+        if (mounted && data?.user)
+          setUser({ id: data.user.id, name: data.user.name });
       } catch (e) {
         // ignore
       }

--- a/src/app/libs/auth.ts
+++ b/src/app/libs/auth.ts
@@ -15,7 +15,9 @@ export interface JWTPayload {
 }
 
 if (!process.env.JWT_SECRET) {
-  console.warn("JWT_SECRET is not set. Set it in your environment for secure tokens.");
+  console.warn(
+    "JWT_SECRET is not set. Set it in your environment for secure tokens."
+  );
 }
 
 export function signToken(payload: JWTPayload) {

--- a/src/lib/__tests__/appointments.test.ts
+++ b/src/lib/__tests__/appointments.test.ts
@@ -1,18 +1,21 @@
-import { describe, it, expect } from 'vitest';
-import { prismaToUI, uiToPrisma } from '@/lib/appointments';
-import { Appointment as PrismaAppointment, AppointmentStatus } from '@/generated/prisma';
+import { describe, it, expect } from "vitest";
+import { prismaToUI, uiToPrisma } from "@/lib/appointments";
+import {
+  Appointment as PrismaAppointment,
+  AppointmentStatus,
+} from "@/generated/prisma";
 
-describe('appointments helper', () => {
-  it('prismaToUI converts prisma appointment to UIAppointment', () => {
+describe("appointments helper", () => {
+  it("prismaToUI converts prisma appointment to UIAppointment", () => {
     const prisma: PrismaAppointment = {
-      id: '1',
-      companyId: 'cmp-1',
-      professionalId: 'prof-1',
-      clientName: 'João',
-      serviceId: 'svc-1',
+      id: "1",
+      companyId: "cmp-1",
+      professionalId: "prof-1",
+      clientName: "João",
+      serviceId: "svc-1",
       price: 50,
-      startTime: new Date('2025-09-30T10:00:00.000Z'),
-      endTime: new Date('2025-09-30T11:00:00.000Z'),
+      startTime: new Date("2025-09-30T10:00:00.000Z"),
+      endTime: new Date("2025-09-30T11:00:00.000Z"),
       status: AppointmentStatus.PENDING,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -20,24 +23,24 @@ describe('appointments helper', () => {
 
     const ui = prismaToUI(prisma);
     expect(ui).not.toBeNull();
-    expect(ui?.id).toBe('1');
-    expect(ui?.clientName).toBe('João');
-    expect(ui?.service).toBe('svc-1');
+    expect(ui?.id).toBe("1");
+    expect(ui?.clientName).toBe("João");
+    expect(ui?.service).toBe("svc-1");
     expect(ui?.price).toBe(50);
-    expect(ui?.date.startsWith('2025-09-30')).toBe(true);
+    expect(ui?.date.startsWith("2025-09-30")).toBe(true);
   });
 
-  it('uiToPrisma converts UI form to prisma payload', () => {
+  it("uiToPrisma converts UI form to prisma payload", () => {
     const form: Record<string, unknown> = {
-      clientName: 'Maria',
-      service: 'svc-2',
+      clientName: "Maria",
+      service: "svc-2",
       price: 80,
-      date: '2025-10-01T09:00',
+      date: "2025-10-01T09:00",
     };
 
     const payload = uiToPrisma(form);
-    expect(payload.clientName).toBe('Maria');
-    expect(payload.serviceId).toBe('svc-2');
-    expect(typeof payload.startTime).toBe('string');
+    expect(payload.clientName).toBe("Maria");
+    expect(payload.serviceId).toBe("svc-2");
+    expect(typeof payload.startTime).toBe("string");
   });
 });

--- a/src/lib/appointments.ts
+++ b/src/lib/appointments.ts
@@ -14,19 +14,26 @@ export interface UIAppointment {
  * Converte um objeto Appointment do Prisma para o formato usado pela UI.
  * Faz parsing seguro de campos opcionais (price, serviceId/startTime etc.).
  */
-export function prismaToUI(appt: PrismaAppointment | null | undefined): UIAppointment | null {
+export function prismaToUI(
+  appt: PrismaAppointment | null | undefined
+): UIAppointment | null {
   if (!appt) return null;
 
   const start = appt.startTime ? new Date(appt.startTime) : new Date();
   // prefer relational `service` string if populated, otherwise fallback to serviceId
   const hasServiceProp = (o: unknown): o is { service?: unknown } => {
-    return !!o && typeof o === "object" && "service" in (o as Record<string, unknown>);
+    return (
+      !!o &&
+      typeof o === "object" &&
+      "service" in (o as Record<string, unknown>)
+    );
   };
 
   const apptRecord = appt as Record<string, unknown>;
-  const service = hasServiceProp(appt) && typeof apptRecord.service === "string"
-    ? (apptRecord.service as string)
-    : appt.serviceId ?? "";
+  const service =
+    hasServiceProp(appt) && typeof apptRecord.service === "string"
+      ? (apptRecord.service as string)
+      : appt.serviceId ?? "";
   return {
     id: appt.id,
     clientName: appt.clientName ?? "",
@@ -42,12 +49,15 @@ export function prismaToUI(appt: PrismaAppointment | null | undefined): UIAppoin
  * Converte o formato UI para o payload esperado pela API/Prisma.
  * Recebe um UIAppointment parcial (form) e converte date (string) para ISO.
  */
-export function uiToPrisma(form: Partial<UIAppointment> & { serviceId?: string }) {
+export function uiToPrisma(
+  form: Partial<UIAppointment> & { serviceId?: string }
+) {
   const startTime = form.date ? new Date(form.date).toISOString() : undefined;
   return {
     clientName: form.clientName,
     // support legacy `service` field from UI forms (fallback) and prefer explicit serviceId
-    serviceId: form.serviceId ?? (form as Record<string, unknown>).service ?? undefined,
+    serviceId:
+      form.serviceId ?? (form as Record<string, unknown>).service ?? undefined,
     price: form.price,
     startTime,
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,9 +23,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,14 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'node',
+    environment: "node",
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      "@": path.resolve(__dirname, "src"),
     },
   },
 });


### PR DESCRIPTION
## Resumo
Corrige erros que impediam o `next build`/deploy na Vercel.  
O build quebrava durante a geração de tipos do **App Router** porque várias rotas API declaravam a segunda assinatura do handler (ex.: `export async function DELETE(req, { params })`) — isso gerava tipos inválidos para o `RouteContext`.  
Em vez de usar o segundo parâmetro, as rotas agora leem o `id` de forma resiliente (**path / query / body**).

---

## Problema
- Next gerava um erro de tipos em `.next/types/...` apontando handlers com `__param_type__.params` incompatível.  
- Essas assinaturas causavam falha na etapa de *Checking validity of types* do `next build`, impedindo deploy.

---

## O que foi feito
- Removido o uso do segundo parâmetro `{ params }` nas handlers API afetadas.  
- Extração de `id` agora ocorre de forma segura:
  - `req.nextUrl.searchParams.get('id')` (query)  
  - `req.nextUrl.pathname` (segmento do caminho)  
  - como fallback, `await req.json()` (body)  
- Mantido comportamento anterior de retornar `400` quando `id` não for encontrado.  
- Testado localmente:
  - `npx tsc --noEmit`  
  - `npx next build`  
  Ambos confirmam que o erro de geração de tipos sumiu. ✅

---

## Arquivos alterados (resumo)
**APIs:**
- `route.ts` (DELETE)  
- `route.ts` (GET)  
- `route.ts` (DELETE)  
- `route.ts` (PUT, DELETE)  
- `route.ts` (PUT, DELETE)  

**Outros (ajustes relacionados incluídos no commit):**
- `src/app/(app)/dashboard/appointments/*`  
- `appointments.ts`, `appointments.test.ts`  
- `tsconfig.json`, `vitest.config.ts`  

*(Para ver o diff exato, consulte o commit na branch `feature/normalize-appointments`.)*

---

## Como validar localmente (rápido)
```sh
# deve terminar sem erros de TS
npx tsc --noEmit

# deve rodar os testes unitários (appointments testados OK)
npx vitest --run

# deve compilar sem erros de tipos
npx next build
