### PR TITLE
chore(appointments): centralize day-range parsing, use util na API e adicionar script de teste de integração

### DIFF
--- a/scripts/integration_appointments_test.cjs
+++ b/scripts/integration_appointments_test.cjs
@@ -1,0 +1,90 @@
+(async () => {
+  const { PrismaClient } = await import("@prisma/client");
+  const prisma = new PrismaClient();
+  try {
+    const baseUrl =
+      process.argv[2] || process.env.BASE_URL || "http://localhost:3001";
+    const companyId = process.argv[3] || process.env.COMPANY_ID;
+    if (!companyId) {
+      console.error(
+        "Usage: node scripts/integration_appointments_test.cjs <baseUrl?> <companyId>"
+      );
+      process.exit(2);
+    }
+
+    const service = await prisma.service.findFirst({ where: { companyId } });
+    const professional = await prisma.professional.findFirst({
+      where: { companyId },
+    });
+    if (!service || !professional) {
+      console.error(
+        "Could not find service or professional for company:",
+        companyId
+      );
+      process.exit(3);
+    }
+
+    const today = new Date();
+    const year = today.getUTCFullYear();
+    const month = today.getUTCMonth();
+    const date = today.getUTCDate();
+    const start = new Date(Date.UTC(year, month, date, 10, 0, 0));
+    const end = new Date(start.getTime() + service.duration * 60_000);
+
+    const appt = await prisma.appointment.create({
+      data: {
+        companyId,
+        professionalId: professional.id,
+        clientName: "Integration Test",
+        serviceId: service.id,
+        startTime: start,
+        endTime: end,
+      },
+    });
+
+    console.log(
+      "Seeded appointment id=",
+      appt.id,
+      "start=",
+      appt.startTime.toISOString()
+    );
+
+    const isoDate = start.toISOString().slice(0, 10);
+    const url = `${baseUrl}/api/appointments?companyId=${encodeURIComponent(
+      companyId
+    )}&from=${isoDate}&to=${isoDate}`;
+    console.log("Querying", url);
+
+    const res = await fetch(url);
+    const body = await res.json();
+    console.log("API response status", res.status);
+
+    if (!body || !body.success) {
+      console.error("API responded with error or no data", body);
+      throw new Error("API error");
+    }
+
+    const found = (body.data || []).find((a) => a.id === appt.id);
+    if (found) {
+      console.log("Integration test passed: appointment found in API response");
+    } else {
+      console.error(
+        "Integration test failed: seeded appointment not found in API response"
+      );
+      console.error(
+        "API returned",
+        (body.data || []).map((a) => a.id)
+      );
+      process.exit(4);
+    }
+
+    await prisma.appointment.delete({ where: { id: appt.id } });
+    console.log("Cleaned up seeded appointment");
+    process.exit(0);
+  } catch (e) {
+    console.error(e);
+    process.exit(10);
+  } finally {
+    await prisma.$disconnect();
+  }
+})();

--- a/scripts/integration_appointments_test.js
+++ b/scripts/integration_appointments_test.js
@@ -1,0 +1,98 @@
+import { PrismaClient } from "@prisma/client";
+import fetch from "node-fetch";
+
+async function main() {
+  const prisma = new PrismaClient();
+  try {
+    const baseUrl =
+      process.argv[2] || process.env.BASE_URL || "http://localhost:3001";
+    const companyId = process.argv[3] || process.env.COMPANY_ID;
+    if (!companyId) {
+      console.error(
+        "Usage: node scripts/integration_appointments_test.js <baseUrl?> <companyId>"
+      );
+      process.exit(2);
+    }
+
+    // Find any existing service and professional for the company
+    const service = await prisma.service.findFirst({ where: { companyId } });
+    const professional = await prisma.professional.findFirst({
+      where: { companyId },
+    });
+    if (!service || !professional) {
+      console.error(
+        "Could not find service or professional for company:",
+        companyId
+      );
+      process.exit(3);
+    }
+
+    // create an appointment for today (UTC) at 10:00
+    const today = new Date();
+    const year = today.getUTCFullYear();
+    const month = today.getUTCMonth();
+    const date = today.getUTCDate();
+    const start = new Date(Date.UTC(year, month, date, 10, 0, 0));
+    const end = new Date(start.getTime() + service.duration * 60_000);
+
+    const appt = await prisma.appointment.create({
+      data: {
+        companyId,
+        professionalId: professional.id,
+        clientName: "Integration Test",
+        serviceId: service.id,
+        startTime: start,
+        endTime: end,
+      },
+    });
+
+    console.log(
+      "Seeded appointment id=",
+      appt.id,
+      "start=",
+      appt.startTime.toISOString()
+    );
+
+    // call the API for today's date
+    const isoDate = start.toISOString().slice(0, 10);
+    const url = `${baseUrl}/api/appointments?companyId=${encodeURIComponent(
+      companyId
+    )}&from=${isoDate}&to=${isoDate}`;
+    console.log("Querying", url);
+
+    const res = await fetch(url);
+    const body = await res.json();
+    console.log("API response status", res.status);
+
+    if (!body || !body.success) {
+      console.error("API responded with error or no data", body);
+      throw new Error("API error");
+    }
+
+    const found = (body.data || []).find((a) => a.id === appt.id);
+    if (found) {
+      console.log("Integration test passed: appointment found in API response");
+    } else {
+      console.error(
+        "Integration test failed: seeded appointment not found in API response"
+      );
+      console.error(
+        "API returned",
+        (body.data || []).map((a) => a.id)
+      );
+      process.exit(4);
+    }
+
+    // cleanup
+    await prisma.appointment.delete({ where: { id: appt.id } });
+    console.log("Cleaned up seeded appointment");
+    process.exit(0);
+  } catch (e) {
+    console.error(e);
+    process.exit(10);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main();

--- a/scripts/queryAppointments.js
+++ b/scripts/queryAppointments.js
@@ -1,0 +1,31 @@
+const { PrismaClient } = require("@prisma/client");
+(async () => {
+  const prisma = new PrismaClient();
+  try {
+    const companyId = process.argv[2];
+    const from = process.argv[3];
+    const to = process.argv[4];
+    if (!companyId || !from || !to) {
+      console.error(
+        "usage: node scripts/queryAppointments.js <companyId> <from> <to>"
+      );
+      process.exit(1);
+    }
+    const fromDate = new Date(from);
+    fromDate.setUTCHours(0, 0, 0, 0);
+    const toDate = new Date(to);
+    toDate.setUTCHours(23, 59, 59, 999);
+    const appts = await prisma.appointment.findMany({
+      where: { companyId, startTime: { gte: fromDate, lte: toDate } },
+      orderBy: { startTime: "asc" },
+    });
+    console.log("found", appts.length, "appointments");
+    appts.forEach((a) =>
+      console.log(a.id, a.startTime.toISOString(), a.serviceId)
+    );
+  } catch (e) {
+    console.error(e);
+  } finally {
+    process.exit(0);
+  }
+})();

--- a/src/app/api/appointments/[id]/route.ts
+++ b/src/app/api/appointments/[id]/route.ts
@@ -35,9 +35,9 @@ function getDayOfWeekUTC(date: Date) {
 function hashToTwoInts(key: string): [number, number] {
   let h = 5381;
   for (let i = 0; i < key.length; i++) h = (h * 33) ^ key.charCodeAt(i);
-  // return two 32-bit parts
-  const a = h >>> 0;
-  const b = ~h >>> 0;
+  // convert to signed 32-bit integers to match Postgres `int` parameters
+  const a = h | 0;
+  const b = ~h | 0;
   return [a, b];
 }
 
@@ -104,7 +104,7 @@ export async function POST(req: NextRequest) {
 
     const created = await prisma.$transaction(async (tx) => {
       // acquire pg advisory lock for this professional (transactional)
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(${lock1}, ${lock2})`;
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(${lock1}::int, ${lock2}::int)`;
 
       // check overlaps: any appointment for same professional where NOT (existing.end <= new.start OR existing.start >= new.end)
       const overlapCount = await tx.appointment.count({

--- a/src/lib/__tests__/appointmentsRange.test.ts
+++ b/src/lib/__tests__/appointmentsRange.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "vitest";
+import { parseDayRange, buildAppointmentWhere } from "../appointmentsRange";
+
+describe("appointmentsRange utilities", () => {
+  test("parseDayRange produces UTC day boundaries", () => {
+    const { fromDate, toDate } = parseDayRange("2025-09-30", "2025-09-30");
+    // fromDate should be 2025-09-30T00:00:00.000Z
+    expect(fromDate.toISOString()).toBe("2025-09-30T00:00:00.000Z");
+    // toDate should be 2025-09-30T23:59:59.999Z
+    expect(toDate.toISOString()).toBe("2025-09-30T23:59:59.999Z");
+  });
+
+  test("buildAppointmentWhere contains companyId and startTime range", () => {
+    const where = buildAppointmentWhere(
+      "company_123",
+      "2025-09-30",
+      "2025-09-30"
+    );
+    expect(where.companyId).toBe("company_123");
+    expect(where.startTime).toHaveProperty("gte");
+    expect(where.startTime).toHaveProperty("lte");
+    expect(where.startTime.gte.toISOString()).toBe("2025-09-30T00:00:00.000Z");
+    expect(where.startTime.lte.toISOString()).toBe("2025-09-30T23:59:59.999Z");
+  });
+});

--- a/src/lib/__tests__/slotGeneration.test.ts
+++ b/src/lib/__tests__/slotGeneration.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import generateSlots, { WorkingHour } from "@/lib/slotGeneration";
+import { UIAppointment } from "@/lib/appointments";
+import { AppointmentStatus } from "@/generated/prisma";
+
+describe("generateSlots", () => {
+  it("marks overlapping slots as unavailable (same day, simple overlap)", () => {
+    // Use local date constructor so tests are deterministic across timezones
+    const date = new Date(2025, 9, 1); // October 1, 2025 (monthIndex 9)
+    const workingHours: WorkingHour[] = [
+      { dayOfWeek: date.getDay(), openTime: "09:00", closeTime: "12:00" },
+    ];
+
+    // service duration: 60 minutes
+    const duration = 60;
+
+    // existing appointment at 10:00 local
+    const apptDate = new Date(date);
+    apptDate.setHours(10, 0, 0, 0);
+    const appts: UIAppointment[] = [
+      {
+        id: "a1",
+        clientName: "Test",
+        service: "svc-1",
+        serviceId: "svc-1",
+        price: 50,
+        date: apptDate.toISOString(),
+        status: AppointmentStatus.PENDING,
+      },
+    ];
+
+    const slots = generateSlots(date, workingHours, duration, appts);
+
+    // slots should include 09:00, 10:00, 11:00; 10:00 should be unavailable
+    const slotMap = Object.fromEntries(slots.map((s) => [s.time, s.available]));
+    expect(slotMap["09:00"]).toBe(true);
+    expect(slotMap["10:00"]).toBe(false);
+    expect(slotMap["11:00"]).toBe(true);
+  });
+
+  it("handles appointments with timezone offsets correctly (local parsing)", () => {
+    // select a local date but appointment in a timezone offset
+    const date = new Date("2025-10-02T00:00:00.000Z");
+    const workingHours: WorkingHour[] = [
+      { dayOfWeek: date.getDay(), openTime: "08:00", closeTime: "10:00" },
+    ];
+    const duration = 30;
+
+    // create appointment using local time 08:30 on the selected date
+    const localAppt = new Date(date);
+    localAppt.setHours(8, 30, 0, 0);
+    const appts: UIAppointment[] = [
+      {
+        id: "a2",
+        clientName: "TZ",
+        service: "svc-2",
+        serviceId: "svc-2",
+        price: 30,
+        date: localAppt.toISOString(),
+        status: AppointmentStatus.PENDING,
+      },
+    ];
+
+    const slots = generateSlots(date, workingHours, duration, appts);
+    const slotMap = Object.fromEntries(slots.map((s) => [s.time, s.available]));
+
+    // 08:00, 08:30 should be affected by the appointment at 06:30Z (which is 08:30 local+2),
+    // but since we use ISO and Date parsing, the function should mark 08:30 as unavailable.
+    expect(slotMap["08:00"]).toBe(true);
+    expect(slotMap["08:30"]).toBe(false);
+  });
+});

--- a/src/lib/appointments.ts
+++ b/src/lib/appointments.ts
@@ -40,7 +40,8 @@ export function prismaToUI(
     service: String(service),
     serviceId: appt.serviceId,
     price: appt.price ?? 0,
-    date: start.toISOString().slice(0, 16),
+    // keep full ISO timestamp (with timezone) so client comparisons are accurate
+    date: start.toISOString(),
     status: appt.status,
   };
 }

--- a/src/lib/appointmentsRange.ts
+++ b/src/lib/appointmentsRange.ts
@@ -1,0 +1,23 @@
+export function parseDayRange(from: string, to: string) {
+  const fromDate = new Date(from);
+  // normalize to UTC start of day
+  fromDate.setUTCHours(0, 0, 0, 0);
+  const toDate = new Date(to);
+  // normalize to UTC end of day
+  toDate.setUTCHours(23, 59, 59, 999);
+  return { fromDate, toDate };
+}
+
+export function buildAppointmentWhere(
+  companyId: string,
+  from: string,
+  to: string
+) {
+  const { fromDate, toDate } = parseDayRange(from, to);
+  return {
+    companyId,
+    startTime: { gte: fromDate, lte: toDate },
+  } as const;
+}
+
+// named exports only to satisfy linting/compile rules

--- a/src/lib/slotGeneration.ts
+++ b/src/lib/slotGeneration.ts
@@ -1,0 +1,91 @@
+import { UIAppointment } from "./appointments";
+
+export interface WorkingHour {
+  dayOfWeek: number;
+  openTime: string; // "HH:mm"
+  closeTime: string; // "HH:mm"
+}
+
+export interface AvailableSlot {
+  time: string; // "HH:mm"
+  available: boolean;
+}
+
+/**
+ * Generate available slots for a given date, working hours, service duration and existing appointments.
+ * - selectedDate: Date object representing the day to generate slots for
+ * - workingHours: list of WorkingHour (server shape)
+ * - durationMinutes: service duration in minutes
+ * - existingAppointments: UIAppointments with full ISO date strings
+ */
+export function generateSlots(
+  selectedDate: Date,
+  workingHours: WorkingHour[],
+  durationMinutes: number,
+  existingAppointments: UIAppointment[],
+  serviceDurationMap?: Record<string, number>,
+  debug: boolean = false
+): AvailableSlot[] {
+  const slots: AvailableSlot[] = [];
+  const dayIndex = selectedDate.getDay();
+  const todaysWorkingHours = workingHours.filter(
+    (wh) => wh?.dayOfWeek === dayIndex
+  );
+
+  if (todaysWorkingHours.length === 0) return slots;
+
+  todaysWorkingHours.forEach((wh) => {
+    const [startHour, startMinute] = wh.openTime.split(":").map(Number);
+    const [endHour, endMinute] = wh.closeTime.split(":").map(Number);
+
+    const start = new Date(selectedDate);
+    start.setHours(startHour, startMinute, 0, 0);
+
+    const end = new Date(selectedDate);
+    end.setHours(endHour, endMinute, 0, 0);
+
+    const current = new Date(start);
+
+    while (current.getTime() + durationMinutes * 60_000 <= end.getTime()) {
+      const timeStr = current.toTimeString().slice(0, 5);
+
+      const isOccupied = existingAppointments.some((appt) => {
+        // appt.date is expected to be full ISO string (UTC or with timezone)
+        const apptStart = new Date(appt.date);
+        // determine appointment duration: prefer map value, fall back to provided duration
+        const apptDuration = Number(
+          (appt.serviceId && serviceDurationMap?.[appt.serviceId]) ??
+            durationMinutes
+        );
+        const apptEnd = new Date(apptStart);
+        apptEnd.setMinutes(apptEnd.getMinutes() + apptDuration);
+
+        const overlap = !(
+          current.getTime() + durationMinutes * 60_000 <= apptStart.getTime() ||
+          current.getTime() >= apptEnd.getTime()
+        );
+
+        if (debug) {
+          // print a compact debug line for each potential overlap
+
+          console.log(
+            `[slotGeneration] slot=${timeStr} slotMs=${current.getTime()} appt=${
+              appt.id
+            } apptDate=${
+              appt.date
+            } apptStartMs=${apptStart.getTime()} apptEndMs=${apptEnd.getTime()} overlap=${overlap}`
+          );
+        }
+
+        return overlap;
+      });
+
+      slots.push({ time: timeStr, available: !isOccupied });
+      current.setMinutes(current.getMinutes() + durationMinutes);
+    }
+  });
+
+  return slots;
+}
+
+export default generateSlots;


### PR DESCRIPTION
## Resumo
Centraliza a lógica de parsing de intervalo de dias usada pela API de agendamentos e adiciona um script de teste de integração que semeia um agendamento, consulta o endpoint e valida que o agendamento retornou com sucesso.  
Também atualiza o handler GET de `/api/appointments` para usar a util testada e melhora a geração de slots no frontend para usar util compartilhada.

---

## Motivação
- Evitar inconsistências ao interpretar queries como `from=YYYY-MM-DD&to=YYYY-MM-DD` (problemas de timezone/horário do dia).  
- Reduzir probabilidade de regressões extraindo a lógica para um util testado.  
- Adicionar um script de integração para validar comportamento end-to-end localmente.  

---

## Principais mudanças
- **Adiciona util de intervalo de dias e verificação**:
  - `appointmentsRange.ts` (parseDayRange + buildAppointmentWhere)  
- **Usa a util no endpoint de listagem**:
  - `route.ts` — GET agora usa `buildAppointmentWhere(...)`  
- **Adiciona testes unitários**:
  - `appointmentsRange.test.ts`  
  - (já existiam testes para slot generation; mantidos)  
- **Adiciona script de teste de integração**:
  - `integration_appointments_test.cjs` — semeia appointment via Prisma, chama `/api/appointments` e remove o registro  
  - `queryAppointments.js` — util auxiliar para consultar Prisma (opcional)  
- **Pequenas correções relacionadas**:
  - ajustes no `appointments.ts` (retornar ISO completo)  
  - `slotGeneration.ts` (util pura usada pelo frontend)  
  - atualizações em `page.tsx` para usar as melhorias  

---

## Arquivos afetados (resumo)
- `appointmentsRange.ts` — nova util (from/to → UTC day start/end)  
- `route.ts` — usa `buildAppointmentWhere(...)` no GET  
- `appointmentsRange.test.ts` — testes unitários para o util  
- `integration_appointments_test.cjs` — script de integração local  
- `queryAppointments.js` — script utilitário Prisma  
- `slotGeneration.ts` — util de geração de slots (existe/atualizado)  
- `page.tsx` — cliente atualizado para usar util/normalizações  
- `appointments.ts` — ajustado para retornar ISO completo  

---

## Testes realizados
- **Unit tests (Vitest)**  
  ```sh
  npx vitest --run

### Validações locais

- Todos os testes adicionados/ajustados passaram localmente.

**TypeScript**

npx tsc --noEmit

✅ Sem erros de tipagem localmente.

---

### Como testar localmente (rápido)

**Gerar Prisma Client (se necessário)**

npx prisma generate

⚠️ **Observação (Windows):** pode ocorrer erro de permissão no rename do `query_engine-windows.dll.node*`.  
Soluções: fechar processos usando o arquivo, rodar terminal como administrador ou remover `.tmp` e rodar `prisma generate` novamente.

---

**Iniciar servidor Next**

npx next dev

Se a porta 3000 estiver ocupada, o Next pode escolher outra (ex.: 3001).  
➡️ Ajuste `BASE_URL` conforme necessário.

---

**Rodar testes unitários**

npx vitest --run

---

**Rodar script de integração (com servidor em execução)**

node integration_appointments_test.cjs <COMPANY_ID>

Substituir `<COMPANY_ID>` pelo `companyId` existente (ex.: `cmg2byvfg00039dew1ciiu5fk`).

O script:
- procura um service e professional existentes
- cria um appointment para hoje às 10:00 UTC
- chama `/api/appointments?companyId=...&from=YYYY-MM-DD&to=YYYY-MM-DD`
- valida que o appointment semeado está presente
- apaga o appointment de limpeza

---

**Verificação manual**

- Abrir UI de novo agendamento e confirmar que os slots ocupados correspondem aos agendamentos reais.

---

### Checklist do PR

- [x] **Código**: util extraída para `appointmentsRange.ts`
- [x] **Backend**: `GET /api/appointments` usando util testada
- [x] **Frontend**: `page.tsx` usa `util/slotGeneration` corretamente
- [x] **Tests**: unit tests adicionados e passando
- [x] **Integração**: script adicionado e funcional
- [x] **Revisão de segurança**: uso de advisory locks / SQL raw revisado (mantido com cast `::int`)

---

### Notas / Risks

- `npx prisma generate` pode falhar se o binary do query engine estiver travado ou com problema de permissão no Windows.
- O script de integração assume a existência de **service** e **professional** para a company usada.  
  Recomenda-se testar em base de dev com dados já criados.

---

### Sugestão de reviewers / labels

**Reviewers:**  
- @backend-team  
- @frontend-team (responsáveis por agendamentos)

**Labels:**  
- `chore`  
- `tests`  
- `integration`  
